### PR TITLE
remove invalid Org3MSP in fabric config files

### DIFF
--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/api/fabric-api-node-prometheus.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/api/fabric-api-node-prometheus.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/api/fabric-api-node.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/api/fabric-api-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-node-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-node-mutual-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-node-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-node-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-node.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-go-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-go-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-java-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-java-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-javascript-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-javascript-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-node-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/samples/fabric-node-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/api/fabric-api-go.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/api/fabric-api-go.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/api/fabric-api-java.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/api/fabric-api-java.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/api/fabric-api-node.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/api/fabric-api-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-node-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-node-mutual-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-node-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-node-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-node.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-go-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-go-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-java-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-java-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-javascript-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-javascript-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-node-samples.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/samples/fabric-node-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-go.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-go.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-java.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-java.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-node-prometheus.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-node-prometheus.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-node.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/api/fabric-api-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node-mutual-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node-prometheus.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node-prometheus.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-go-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-go-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-java-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-java-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-javascript-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-javascript-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-node-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/samples/fabric-node-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-go.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-go.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-java.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-java.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-node-prometheus.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-node-prometheus.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-node.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/api/fabric-api-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node-mutual-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node-prometheus.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node-prometheus.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node-tls.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-node.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-go-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-go-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-java-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-java-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-javascript-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-javascript-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-node-samples.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/samples/fabric-node-samples.yaml
@@ -61,7 +61,7 @@ channels:
     definition:
         capabilities: []
         consortium: 'SampleConsortium'
-        msps: ['Org1MSP', 'Org2MSP', 'Org3MSP']
+        msps: ['Org1MSP', 'Org2MSP']
         version: 0
     orderers:
     - orderer.example.com


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

The fabric config files have an unreq'd Org3MSP ... which will fail validation in Caliper vNext that has a validator in it 👍 