### PR TITLE
add example prometheus config file

### DIFF
--- a/benchmarks/samples/fabric/marbles/config-prometheus.yaml
+++ b/benchmarks/samples/fabric/marbles/config-prometheus.yaml
@@ -1,0 +1,68 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+test:
+  clients:
+    type: local
+    number: 5
+  rounds:
+  - label: init
+    txDuration:
+    - 50
+    rateControl:
+    - type: fixed-rate
+      opts:
+        tps: 25
+    callback: benchmarks/samples/fabric/marbles/init.js
+  # - label: query
+  #   txDuration:
+  #   - 15
+  #   rateControl:
+  #   - type: fixed-rate
+  #     opts:
+  #       tps: 5
+  #   callback: benchmarks/samples/fabric/marbles/query.js
+observer:
+  type: prometheus
+  interval: 5
+monitor:
+  type:
+  - docker
+  - process
+  - prometheus
+  docker:
+    name:
+    - all
+  process:
+  - command: node
+    arguments: local-client.js
+    multiOutput: avg
+  prometheus:
+    push_url: "http://localhost:9091"
+    url: "http://localhost:9090"
+    metrics:
+      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
+      include:
+        Endorse Time (s):
+          query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[5m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[5m])
+          step: 1
+          label: instance		
+          statistic: avg
+        Max Memory (MB):
+          query: sum(container_memory_rss{name=~".+"}) by (name)
+          step: 10
+          label: name		
+          statistic: max
+          multiplier: 0.000001


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

With the inbound enablement of prometheus in caliper (spoilers) we should have a config file that can use it