### PR TITLE
fix goLang metadata paths in network files

### DIFF
--- a/networks/fabric/fabric-v1.1/2org1peercouchdb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.1/2org1peercouchdb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.1/2org1peercouchdb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.1/2org1peercouchdb/fabric-go-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.1/2org1peercouchdb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.1/2org1peercouchdb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.1/2org1peergoleveldb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.1/2org1peergoleveldb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.1/2org1peergoleveldb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.1/2org1peergoleveldb/fabric-go-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.1/2org1peergoleveldb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.1/2org1peergoleveldb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.2/2org1peercouchdb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.2/2org1peercouchdb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.2/2org1peercouchdb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.2/2org1peercouchdb/fabric-go-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.2/2org1peercouchdb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.2/2org1peercouchdb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.2/2org1peergoleveldb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.2/2org1peergoleveldb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.2/2org1peergoleveldb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.2/2org1peergoleveldb/fabric-go-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.2/2org1peergoleveldb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.2/2org1peergoleveldb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.3/2org1peergoleveldb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.3/2org1peergoleveldb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.3/2org1peergoleveldb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.3/2org1peergoleveldb/fabric-go-tls.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.3/2org1peergoleveldb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.3/2org1peergoleveldb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-go-tls.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peercouchdb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-go-tls.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb_kafka/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb_kafka/fabric-go-tls.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.0/2org1peergoleveldb_kafka/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.4.0/2org1peergoleveldb_kafka/fabric-go.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-go-tls.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb/fabric-go.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb_raft/fabric-go-tls-solo.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb_raft/fabric-go-tls-solo.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peercouchdb_raft/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peercouchdb_raft/fabric-go-tls.yaml
@@ -75,7 +75,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go-mutual-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go-mutual-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go-tls.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb/fabric-go.yaml
@@ -72,7 +72,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb_raft/fabric-go-tls-solo.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb_raft/fabric-go-tls-solo.yaml
@@ -73,7 +73,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang

--- a/networks/fabric/fabric-v1.4.1/2org1peergoleveldb_raft/fabric-go-tls.yaml
+++ b/networks/fabric/fabric-v1.4.1/2org1peergoleveldb_raft/fabric-go-tls.yaml
@@ -75,7 +75,7 @@ channels:
       version: v0
       language: golang
       path: fabric/samples/marbles/go
-      metadatapath: src/fabric/samples/marbles/go/metadata
+      metadataPath: src/fabric/samples/marbles/go/metadata
     - id: drm
       version: v0
       language: golang


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

fabric networks have incorrect `metadataPath` label that now fails validation ... this corrects the label name