### PR TITLE
fixing missing decimal

### DIFF
--- a/docs/fabric/performance/1.4.0/nodeJS/nodeSDK/submit/empty-contract.md
+++ b/docs/fabric/performance/1.4.0/nodeJS/nodeSDK/submit/empty-contract.md
@@ -25,7 +25,7 @@ Resource utilization is investigated for fixed TPS rate of 350TPS.
 | Type | Policy | Max Latency (s) | Avg Latency (s) | Throughput (TPS) |
 | ---- | ------ | --------------- | --------------- | ---------------- |
 | submit | 1-of-any | 0.52 | 0.11 | 380.5 |
-| submit | 2-of-any | 0.32 | 0.13 | 3387 |
+| submit | 2-of-any | 0.32 | 0.13 | 338.7 |
 
 *LevelDB Resource Utilization– Submit By Policy @350TPS*
 ![submit empty contract fabric with LevelDB resource utilization](../../../../../charts/1.4.0/nodeJS/nodeSDK/policies/LevelDB_submitByPolicy.png)


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

decimal point missing in the benchmark result highline