### PR TITLE
Fixed tps fix in fabric API test

### DIFF
--- a/benchmarks/api/fabric/levelDB/create-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/create-asset-batch.yaml
@@ -6,7 +6,7 @@ test:
     added into the world state database.
   workers:
     type: local
-    number: 4
+    number: 10
   rounds:
   - label: create-asset-batch-20-8000-fixed-tps
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database at a fixed TPS.
@@ -21,7 +21,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 1 assets of size 8k bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2} }
     arguments:
       bytesize: 8000
       batchsize: 1
@@ -30,7 +30,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 10 assets of size 8k bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2} }
     arguments:
       bytesize: 8000
       batchsize: 10
@@ -39,7 +39,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2} }
     arguments:
       bytesize: 8000
       batchsize: 20
@@ -48,7 +48,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 30 assets of size 8k bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2} }
     arguments:
       bytesize: 8000
       batchsize: 30
@@ -57,7 +57,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 40 assets of size 8k bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2} }
     arguments:
       bytesize: 8000
       batchsize: 40
@@ -66,7 +66,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 50 assets of size 8k bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2} }
     arguments:
       bytesize: 8000
       batchsize: 50

--- a/benchmarks/api/fabric/levelDB/create-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/create-asset.yaml
@@ -6,7 +6,7 @@ test:
     added into the world state database.
   workers:
     type: local
-    number: 10
+    number: 25
   rounds:
   - label: create-asset-8000-fixed-tps
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database at a fixed TPS rate.
@@ -20,7 +20,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 100 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 100
     callback: benchmarks/api/fabric/lib/create-asset.js
@@ -28,7 +28,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 2000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 2000
     callback: benchmarks/api/fabric/lib/create-asset.js
@@ -36,7 +36,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 4000
     callback: benchmarks/api/fabric/lib/create-asset.js
@@ -44,7 +44,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 8000
     callback: benchmarks/api/fabric/lib/create-asset.js
@@ -52,7 +52,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 16000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 16000
     callback: benchmarks/api/fabric/lib/create-asset.js
@@ -60,7 +60,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 32000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 32000
     callback: benchmarks/api/fabric/lib/create-asset.js
@@ -68,7 +68,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 64000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2 } }
     arguments:
       bytesize: 64000
     callback: benchmarks/api/fabric/lib/create-asset.js

--- a/benchmarks/api/fabric/levelDB/delete-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/delete-asset-batch.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round invokes the `deleteAssetsFromBatch` API method. Successive rounds delete a-priori created assets of larger byte size.
   workers:
     type: local
-    number: 10
+    number: 25
   rounds:
   - label: delete-asset-batch-1-8000
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 1 UUID that matches an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000 # max number = (arguments.assets/assets.batchsize)
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [8000]
       assets: 4000
@@ -23,7 +23,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [8000]
       assets: 40000
@@ -35,7 +35,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [8000]
       assets: 80000
@@ -47,7 +47,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [8000]
       assets: 30000
@@ -59,7 +59,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [8000]
       assets: 40000
@@ -71,7 +71,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 500
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [8000]
       assets: 25000

--- a/benchmarks/api/fabric/levelDB/delete-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/delete-asset.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round invokes the 'deleteAsset' method. Successive rounds delete a-priori created assets of larger bytesize.
   workers:
     type: local
-    number: 5
+    number: 20
   rounds:
   - label: delete-asset-100
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 100 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
       assets: 4000
@@ -22,7 +22,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 1000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       assets: 4000
@@ -33,7 +33,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 2000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       bytesize: 2000
@@ -44,7 +44,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 4000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       bytesize: 4000
@@ -55,7 +55,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       bytesize: 8000
@@ -66,7 +66,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 16000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       bytesize: 16000
@@ -77,7 +77,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 32000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       bytesize: 32000
@@ -88,7 +88,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 64000 bytes.
     chaincodeId: fixed-asset
     txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 2, startingTps: 10} }
     arguments:
       nosetup: true
       bytesize: 64000

--- a/benchmarks/api/fabric/levelDB/empty-contract-1of.yaml
+++ b/benchmarks/api/fabric/levelDB/empty-contract-1of.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
   workers:
     type: local
-    number: 10
+    number: 25
   rounds:
   - label: empty-contract-evaluate
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
     arguments:
       consensus: false
     callback: benchmarks/api/fabric/lib/empty-contract.js
@@ -19,7 +19,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
     arguments:
       consensus: true
     callback: benchmarks/api/fabric/lib/empty-contract.js

--- a/benchmarks/api/fabric/levelDB/empty-contract-2of.yaml
+++ b/benchmarks/api/fabric/levelDB/empty-contract-2of.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
   workers:
     type: local
-    number: 10
+    number: 25
   rounds:
   - label: empty-contract-evaluate
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
     arguments:
       consensus: false
     callback: benchmarks/api/fabric/lib/empty-contract.js
@@ -19,7 +19,7 @@ test:
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
     arguments:
       consensus: true
     callback: benchmarks/api/fabric/lib/empty-contract.js

--- a/benchmarks/api/fabric/levelDB/get-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/get-asset-batch.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round invokes the `getAssetsFromBatch` API method. Successive rounds create and retrieve assets of larger bytesize.
   workers:
     type: local
-    number: 10
+    number: 25
   rounds:
   - label: get-asset-batch-evaluate-1-8000
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 1 UUID that matches an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2 } }
     arguments:
       create_sizes: [8000]
       assets: 8000
@@ -23,7 +23,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2 } }
     arguments:
       create_sizes: [8000]
       assets: 8000
@@ -35,7 +35,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2 } }
     arguments:
       nosetup: true
       assets: 8000
@@ -47,7 +47,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2 } }
     arguments:
       nosetup: true
       assets: 8000
@@ -59,7 +59,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2 } }
     arguments:
       nosetup: true
       assets: 8000
@@ -71,7 +71,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2 } }
     arguments:
       nosetup: true
       assets: 8000

--- a/benchmarks/api/fabric/levelDB/get-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/get-asset.yaml
@@ -100,7 +100,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
+    rateControl: { type: fixed-rate, opts: { tps: 350 }}
     arguments:
       nosetup: true
       bytesize: 8000

--- a/benchmarks/api/fabric/levelDB/get-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/get-asset.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round invokes the 'getAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
   workers:
     type: local
-    number: 10
+    number: 25
   rounds:
   - label: get-asset-evaluate-100
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 100 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
       assets: 1000
@@ -23,7 +23,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 1000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 1000
@@ -34,7 +34,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 2000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 2000
@@ -45,7 +45,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 4000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 4000
@@ -56,7 +56,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 8000
@@ -67,7 +67,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 16000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 16000
@@ -78,7 +78,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 32000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 32000
@@ -89,7 +89,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 64000 bytes.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 64000
@@ -100,7 +100,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 10 } }
     arguments:
       nosetup: true
       bytesize: 8000

--- a/benchmarks/api/fabric/levelDB/mixed-range-query-pagination.yaml
+++ b/benchmarks/api/fabric/levelDB/mixed-range-query-pagination.yaml
@@ -5,13 +5,13 @@ test:
     a Fabric-SDK-Node Gateway. Each test round invokes the 'paginatedRangeQuery' method against a DB populated with mixed size assets. Successive rounds increase the pagesize of retrieved assets.
   workers:
     type: local
-    number: 4
+    number: 25
   rounds:
   - label: mixed-range-query-evaluate-10
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
+    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 1   } }
     arguments:
       create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
       assets: 8000
@@ -25,7 +25,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
+    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 1   } }
     arguments:
       range: 200
       offset: 100
@@ -37,7 +37,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 50 and a range keys that bound 200 assets created by the calling client.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
+    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 1   } }
     arguments:
       range: 200
       offset: 100
@@ -49,7 +49,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 100 and a range keys that bound 200 assets created by the calling client.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 1   } }
     arguments:
       range: 200
       offset: 100
@@ -61,7 +61,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 200 and a range keys that bound 200 assets created by the calling client.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 1   } }
     arguments:
       range: 200
       offset: 100
@@ -73,7 +73,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 500 and a range keys that bound 500 assets created by the calling client.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
+    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 1   } }
     arguments:
       range: 200
       offset: 100

--- a/networks/prometheus-grafana/docker-compose-fabric.yaml
+++ b/networks/prometheus-grafana/docker-compose-fabric.yaml
@@ -60,10 +60,11 @@ services:
     privileged: true
     container_name: cadvisor
     volumes:
+      - /:/rootfs:ro
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
-      # - /cgroup:/cgroup:ro
+      - /sys/fs/cgroup:/cgroup:ro
     ports:
       - 8080:8080
     restart: always


### PR DESCRIPTION
Within the api testing, a round should be run at a fixed rate ... but it wasn't being run that way. This changes enforces the correct rate control to be applied.