### PR TITLE
Correct benchmark rate controller

### DIFF
--- a/benchmarks/api/fabric/levelDB/get-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/get-asset.yaml
@@ -100,7 +100,7 @@ test:
     description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
     chaincodeId: fixed-asset
     txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
+    rateControl: { type: fixed-rate, opts: { tps: 350 }}
     arguments:
       nosetup: true
       bytesize: 8000


### PR DESCRIPTION
Correct the rate controller to provide a fixed tps rate run as the round declares it to do

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>