### PR TITLE
Add previous forks to Ethereum config

### DIFF
--- a/networks/ethereum/1node-clique/data/genesis.json
+++ b/networks/ethereum/1node-clique/data/genesis.json
@@ -2,6 +2,13 @@
     "config": {
         "chainId": 48122,
         "istanbulBlock": 0,
+        "petersburgBlock": 0,
+        "constantinopleBlock": 0,
+        "byzantiumBlock": 0,
+        "eip158Block": 0,
+        "eip155Block": 0,
+        "eip150Block": 0,
+        "homesteadBlock": 0,
         "clique": {
             "period": 5,
             "epoch": 30000

--- a/networks/ethereum/1node/data/genesis.json
+++ b/networks/ethereum/1node/data/genesis.json
@@ -2,6 +2,13 @@
   "config": {
     "chainId": 21194,
     "istanbulBlock": 0,
+    "petersburgBlock": 0,
+    "constantinopleBlock": 0,
+    "byzantiumBlock": 0,
+    "eip158Block": 0,
+    "eip155Block": 0,
+    "eip150Block": 0,
+    "homesteadBlock": 0,
     "ethash": {}
   },
   "nonce": "0x0",


### PR DESCRIPTION
Fixes #68 

When building the image, this will produce an intermittent error,
```
Import error  err="invalid block 18: unknown ancestor"
```
, however building of the image will still be successful. 

I suspect that `bc.dat` doesn't fit the `genesis.json` in this case, but haven't investigated this issue any further yet. 

