### PR TITLE
Add additional test in focal area of reports

### DIFF
--- a/benchmarks/api/fabric/couchDB/create-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/create-asset.yaml
@@ -24,13 +24,13 @@ test:
     arguments:
       bytesize: 100
     callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 2000 bytes into the World State database.
+  - label: create-asset-1000
+    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 1000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
     rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
     arguments:
-      bytesize: 2000
+      bytesize: 1000
     callback: benchmarks/api/fabric/lib/create-asset.js
   - label: create-asset-4000
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.
@@ -55,6 +55,14 @@ test:
     rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
     arguments:
       bytesize: 16000
+    callback: benchmarks/api/fabric/lib/create-asset.js
+  - label: create-asset-24000
+    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 24000 bytes into the World State database.
+    chaincodeId: fixed-asset
+    txDuration: 300
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
+    arguments:
+      bytesize: 24000
     callback: benchmarks/api/fabric/lib/create-asset.js
   - label: create-asset-32000
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 32000 bytes into the World State database.

--- a/benchmarks/api/fabric/couchDB/delete-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/delete-asset.yaml
@@ -13,7 +13,7 @@ test:
     txNumber: 4000
     rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
     arguments:
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
+      create_sizes: [100,1000,4000,8000,16000,24000,32000,64000]
       assets: 4000
       bytesize: 100
       consensus: true
@@ -27,17 +27,6 @@ test:
       nosetup: true
       assets: 4000
       bytesize: 1000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 2000 bytes.
-    chaincodeId: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
-      nosetup: true
-      bytesize: 2000
-      assets: 4000
       consensus: true
     callback: benchmarks/api/fabric/lib/delete-asset.js
   - label: delete-asset-4000
@@ -70,6 +59,17 @@ test:
     arguments:
       nosetup: true
       bytesize: 16000
+      assets: 4000
+      consensus: true
+    callback: benchmarks/api/fabric/lib/delete-asset.js
+  - label: delete-asset-24000
+    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 24000 bytes.
+    chaincodeId: fixed-asset
+    txNumber: 4000
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    arguments:
+      nosetup: true
+      bytesize: 24000
       assets: 4000
       consensus: true
     callback: benchmarks/api/fabric/lib/delete-asset.js

--- a/benchmarks/api/fabric/levelDB/create-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/create-asset.yaml
@@ -24,13 +24,13 @@ test:
     arguments:
       bytesize: 100
     callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 2000 bytes into the World State database.
+  - label: create-asset-1000
+    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 1000 bytes into the World State database.
     chaincodeId: fixed-asset
     txDuration: 300
     rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
     arguments:
-      bytesize: 2000
+      bytesize: 1000
     callback: benchmarks/api/fabric/lib/create-asset.js
   - label: create-asset-4000
     description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.

--- a/benchmarks/api/fabric/levelDB/delete-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/delete-asset.yaml
@@ -13,7 +13,7 @@ test:
     txNumber: 4000
     rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
     arguments:
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
+      create_sizes: [100,1000,4000,8000,16000,24000,32000,64000]
       assets: 4000
       bytesize: 100
       consensus: true
@@ -27,17 +27,6 @@ test:
       nosetup: true
       assets: 4000
       bytesize: 1000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 2000 bytes.
-    chaincodeId: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
-      nosetup: true
-      bytesize: 2000
-      assets: 4000
       consensus: true
     callback: benchmarks/api/fabric/lib/delete-asset.js
   - label: delete-asset-4000
@@ -70,6 +59,17 @@ test:
     arguments:
       nosetup: true
       bytesize: 16000
+      assets: 4000
+      consensus: true
+    callback: benchmarks/api/fabric/lib/delete-asset.js
+  - label: delete-asset-24000
+    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 24000 bytes.
+    chaincodeId: fixed-asset
+    txNumber: 4000
+    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
+    arguments:
+      nosetup: true
+      bytesize: 24000
       assets: 4000
       consensus: true
     callback: benchmarks/api/fabric/lib/delete-asset.js


### PR DESCRIPTION
Based on the latest benchmark reports, something interesting is occurring between the 32 and 64KB range for asset create and delete - this adds an additional round there and removes a redundant 2KB item, whilst aligning the delete and create benchmarks

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>