### PR TITLE
Ensure object reset within init

### DIFF
--- a/benchmarks/api/fabric/lib/batch-create-asset.js
+++ b/benchmarks/api/fabric/lib/batch-create-asset.js
@@ -28,7 +28,7 @@ const bytes = (s) => {
 let txIndex = 0;
 let chaincodeID;
 let clientIdx;
-let asset = {docType: chaincodeID, content: ''};
+let asset;
 let bc, contx, bytesize, batchsize;
 
 module.exports.init = async function(blockchain, context, args) {
@@ -40,6 +40,7 @@ module.exports.init = async function(blockchain, context, args) {
     bytesize = args.bytesize ? parseInt(args.bytesize) : 100;
     batchsize = args.batchsize ? parseInt(args.batchsize) : 1;
 
+    asset = {docType: chaincodeID, content: ''};
     asset.creator = 'client' + clientIdx;
     asset.bytesize = bytesize;
 

--- a/benchmarks/api/fabric/lib/create-asset.js
+++ b/benchmarks/api/fabric/lib/create-asset.js
@@ -30,7 +30,7 @@ const bytes = (s) => {
 
 let txIndex = 0;
 let clientIdx;
-let asset = {docType: chaincodeID, content: ''};
+let asset;
 let bc, contx, bytesize;
 
 module.exports.init = async function(blockchain, context, args) {
@@ -40,6 +40,7 @@ module.exports.init = async function(blockchain, context, args) {
     chaincodeID = args.chaincodeID ? args.chaincodeID : 'fixed-asset';
     bytesize = args.bytesize;
 
+    asset = {docType: chaincodeID, content: ''};
     asset.creator = 'client' + clientIdx;
     asset.bytesize = bytesize;
 

--- a/benchmarks/api/fabric/lib/create-private-asset.js
+++ b/benchmarks/api/fabric/lib/create-private-asset.js
@@ -12,7 +12,7 @@ const bytes = (s) => {
 };
 let txIndex = 0;
 let clientIdx;
-let asset = {docType: chaincodeID, content: ''};
+let asset;
 let bc, contx, bytesize;
 
 module.exports.init = async function(blockchain, context, args) {
@@ -21,6 +21,7 @@ module.exports.init = async function(blockchain, context, args) {
     clientIdx = context.clientIdx;
     bytesize = args.bytesize;
 
+    asset = {docType: chaincodeID, content: ''};
     asset.creator = 'client' + clientIdx;
     asset.bytesize = bytesize;
 


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

Issue relating to the create benchmarks - the innit phase does not currently reset the object, meaning that a 8k asset test, followed by a 100byte asset test would retain the 8k asset size.