### PR TITLE
Update benchmark config structure

### DIFF
--- a/benchmarks/api/fabric/couchDB/base/base.yaml
+++ b/benchmarks/api/fabric/couchDB/base/base.yaml
@@ -1,178 +1,301 @@
----
 test:
   name: fixed-asset-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round flexes a single chaincode method, and includes a null-operation to act as a performance cost baseline.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes a single chaincode method, and includes a null-operation to act
+    as a performance cost baseline.
   workers:
     type: local
     number: 5
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: create-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `create`, which performs a `putState()` operation on an asset of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
+    - label: create-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `create`, which performs a
+        `putState()` operation on an asset of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 1000
-      assets: 500
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 1000
+          assets: 500
+          consensus: false
+    - label: get-asset-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 1000
-      assets: 500
-      consensus: true
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: rich-query-evaluate-0
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches no assets in the world state database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 1000
+          assets: 500
+          consensus: true
+    - label: rich-query-evaluate-0
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches no assets in the world state database.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: rich-query-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches all assets created by the calling client. Each returned asset is of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          nomatch: true
+          consensus: false
+    - label: rich-query-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: rich-query-submit-0
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches no assets in the world state database. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          consensus: false
+    - label: rich-query-submit-0
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches no assets in the world state database. This
+        test includes involvement of the orderer, and appending to the ledger.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      nomatch: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: rich-query-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches all assets created by the calling client. Each returned asset is of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          nomatch: true
+          consensus: true
+    - label: rich-query-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 1000 bytes. This test includes involvement of
+        the orderer, and appending to the ledger.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: range-query-evaluate-0
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no assets in the world state database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          consensus: true
+    - label: range-query-evaluate-0
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no assets in the
+        world state database.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: range-query-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-0
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no items in the world state database. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          consensus: false
+    - label: range-query-submit-0
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no items in the
+        world state database. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      nomatch: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          nomatch: true
+          consensus: true
+    - label: range-query-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes. This test includes
+        involvement of the orderer, and appending to the ledger.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          consensus: true
 monitor:
   interval: 5
-  type: ['process', 'docker']
+  type:
+    - process
+    - docker
   process:
-    processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    processes:
+      - command: node
+        arguments: fabricClientWorker.js
+        multiOutput: avg
   docker:
-    containers: ['all']
+    containers:
+      - all
 observer:
   type: local
   interval: 30

--- a/benchmarks/api/fabric/couchDB/base/create-asset-batch.yaml
+++ b/benchmarks/api/fabric/couchDB/base/create-asset-batch.yaml
@@ -1,126 +1,198 @@
----
 test:
   name: create-asset-batch-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAssetsFromBatch` method, with successive rounds increasing the batch size of the assets being
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAssetsFromBatch` method, with successive rounds
+    increasing the batch size of the assets being added into the world state
+    database.
   workers:
     type: local
     number: 4
   rounds:
-  - label: create-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 5} }
-    arguments:
+    - label: create-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database at a fixed TPS.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 1 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 1 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 1
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 10 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 1
+    - label: create-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 10 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 10
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 10
+    - label: create-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 30 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 30 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 30
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 40 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 30
+    - label: create-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 40 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 40
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 50 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 40
+    - label: create-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 50 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 50
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 50
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/create-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/base/create-asset.yaml
@@ -1,128 +1,207 @@
----
 test:
   name: create-asset-size-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAsset` method, with successive rounds increasing the bytesize of the asset
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAsset` method, with successive rounds increasing
+    the bytesize of the asset added into the world state database.
   workers:
     type: local
     number: 5
   rounds:
-  - label: create-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database at a fixed TPS rate.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 15} }
-    arguments:
+    - label: create-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database at a fixed TPS
+        rate.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 100 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 15
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+    - label: create-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 100 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 100
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 2000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 100
+    - label: create-asset-2000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 2000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 2000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 2000
+    - label: create-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 4000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 4000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 4000
+    - label: create-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 16000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+    - label: create-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 16000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 16000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 32000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 16000
+    - label: create-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 32000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 32000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 64000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 32000
+    - label: create-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 64000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 64000
-    callback: benchmarks/api/fabric/lib/create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 64000
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/delete-asset-batch.yaml
+++ b/benchmarks/api/fabric/couchDB/base/delete-asset-batch.yaml
@@ -1,149 +1,233 @@
----
 test:
   name: delete-asset-batch-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `deleteAssetsFromBatch` API method. Successive rounds delete a-priori created assets of larger byte size.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `deleteAssetsFromBatch` API method. Successive rounds
+    delete a-priori created assets of larger byte size.
   workers:
     type: local
     number: 10
   rounds:
-  - label: delete-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000 # max number = (arguments.assets/assets.batchsize)
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 1 UUID that matches an asset
+        of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 4000
-      bytesize: 8000
-      batchsize: 1
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 4000
+          bytesize: 8000
+          batchsize: 1
+          consensus: true
+    - label: delete-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 10
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 10
+          consensus: true
+    - label: delete-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
+    - label: delete-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 30000
-      bytesize: 8000
-      batchsize: 30
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 30000
+          bytesize: 8000
+          batchsize: 30
+          consensus: true
+    - label: delete-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 40
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 500
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 40
+          consensus: true
+    - label: delete-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 25000
-      bytesize: 8000
-      batchsize: 50
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 30 }}
-    arguments:
+      txNumber: 500
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 25000
+          bytesize: 8000
+          batchsize: 50
+          consensus: true
+    - label: delete-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:
   type: prometheus
   interval: 10
-

--- a/benchmarks/api/fabric/couchDB/base/delete-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/base/delete-asset.yaml
@@ -1,163 +1,267 @@
----
 test:
   name: delete-asset-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'deleteAsset' method. Successive rounds delete a-priori created assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'deleteAsset' method. Successive rounds delete a-priori
+    created assets of larger bytesize.
   workers:
     type: local
     number: 5
   rounds:
-  - label: delete-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 100
+        bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 4000
-      bytesize: 100
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 4000
+          bytesize: 100
+          consensus: true
+    - label: delete-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 1000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 4000
-      bytesize: 1000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 4000
+          bytesize: 1000
+          consensus: true
+    - label: delete-asset-2000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 2000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 2000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 2000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 4000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 4000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 4000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 16000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 16000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 32000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 32000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 64000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 64000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes at a fixed TPS.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/empty-contract-1of.yaml
+++ b/benchmarks/api/fabric/couchDB/base/empty-contract-1of.yaml
@@ -1,91 +1,143 @@
----
 test:
   name: empty-contract-couchDB-1of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 750 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/empty-contract-2of.yaml
+++ b/benchmarks/api/fabric/couchDB/base/empty-contract-2of.yaml
@@ -1,91 +1,145 @@
----
 test:
   name: empty-contract-couchDB-2of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100, startingTps: 10} }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 750 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/fixed-tps-runs.yaml
+++ b/benchmarks/api/fabric/couchDB/base/fixed-tps-runs.yaml
@@ -1,4 +1,3 @@
----
 test:
   name: fixed-tps-runs
   description: Benchmark run to enable resource comparison for benchmarks
@@ -6,106 +5,174 @@ test:
     type: local
     number: 10
   rounds:
-  - label: create-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 100} }
-    arguments:
+    - label: create-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+    - label: create-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: get-asset-evaluate-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 20
+    - label: get-asset-evaluate-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-batch-evaluate-20-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl:  { type: fixed-rate, opts: { tps: 50} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          bytesize: 8000
+          assets: 1000
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: mixed-range-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl:  { type: fixed-rate, opts: { tps: 30} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 50
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
+    - label: mixed-range-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '20'
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '20'
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/get-asset-batch.yaml
+++ b/benchmarks/api/fabric/couchDB/base/get-asset-batch.yaml
@@ -1,146 +1,219 @@
----
 test:
   name: get-asset-batch-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `getAssetsFromBatch` API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `getAssetsFromBatch` API method. Successive rounds create
+    and retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-batch-evaluate-1-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+    - label: get-asset-batch-evaluate-1-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 1 UUID that matches an asset of
+        size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 1
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-10-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 1
+          consensus: false
+    - label: get-asset-batch-evaluate-10-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 10
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 10
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-30-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
+    - label: get-asset-batch-evaluate-30-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 30
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-40-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 30
+          consensus: false
+    - label: get-asset-batch-evaluate-40-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 40
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-50-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 40
+          consensus: false
+    - label: get-asset-batch-evaluate-50-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 50
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 30 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 50
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/get-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/base/get-asset.yaml
@@ -1,163 +1,254 @@
----
 test:
   name: get-asset-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'getAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'getAsset()' API method. Successive rounds create and
+    retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+    - label: get-asset-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 100 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 1000
-      bytesize: 100
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 1000
+          bytesize: 100
+          consensus: false
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 1000
-      bytesize: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-2000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 1000
+          bytesize: 1000
+          consensus: false
+    - label: get-asset-evaluate-2000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 2000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 2000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-4000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 2000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-4000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 4000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 4000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 4000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-16000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-16000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 16000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-32000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 16000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-32000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 32000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-64000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 32000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-64000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 64000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 64000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes
+        at a fixed TPS.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/mixed-range-query-pagination.yaml
+++ b/benchmarks/api/fabric/couchDB/base/mixed-range-query-pagination.yaml
@@ -1,148 +1,230 @@
----
 test:
   name: fixed-asset-mixed-range-query-pagination-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'paginatedRangeQuery' method against a DB populated with mixed size assets. Successive rounds increase the pagesize of retrieved assets.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'paginatedRangeQuery' method against a DB populated with
+    mixed size assets. Successive rounds increase the pagesize of retrieved
+    assets.
   workers:
     type: local
     number: 4
   rounds:
-  - label: mixed-range-query-evaluate-10
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+    - label: mixed-range-query-evaluate-10
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 8000
-      range: 200
-      offset: 100
-      pagesize: '10'
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 8000
+          range: 200
+          offset: 100
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-50
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 50 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-50
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 50
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '50'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 100 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '50'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 100
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '100'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 200 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '100'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 200
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '200'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-300
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 500 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '200'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-300
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 500
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '300'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 10 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '300'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client at
+        a fixed TPS.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/base/mixed-rich-query-pagination.yaml
+++ b/benchmarks/api/fabric/couchDB/base/mixed-rich-query-pagination.yaml
@@ -1,127 +1,233 @@
----
 test:
   name: fixed-asset-mixed-rich-query-pagination-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'pageinatedRichQuery' chaincode method.  Successive rounds increase the pagesize of retrieved assets.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'pageinatedRichQuery' chaincode method.  Successive rounds
+    increase the pagesize of retrieved assets.
   workers:
     type: local
     number: 4
   rounds:
-  - label: mixed-rich-query-evaluate-10
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`.  This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+    - label: mixed-rich-query-evaluate-10
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`.  This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000]
-      assets: 8000
-      pagesize: '10'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 20 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          assets: 8000
+          pagesize: '10'
+          consensus: false
+    - label: mixed-rich-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 20 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-50
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 50 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '20'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-50
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 50 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '50'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 100 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '50'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 100
+        and query string that matches all assets created by the calling client.
+        Each returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '100'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 200 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '100'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 200
+        and query string that matches all assets created by the calling client.
+        Each returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '200'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-500
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 500 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '200'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-500
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 500
+        and query string that matches all assets created by the calling client.
+        Each returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '500'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '500'
+          nosetup: true
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/base.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/base.yaml
@@ -1,178 +1,301 @@
----
 test:
   name: fixed-asset-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round flexes a single chaincode method, and includes a null-operation to act as a performance cost baseline.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes a single chaincode method, and includes a null-operation to act
+    as a performance cost baseline.
   workers:
     type: local
     number: 5
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: create-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `create`, which performs a `putState()` operation on an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
+    - label: create-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `create`, which performs a
+        `putState()` operation on an asset of size 1000 bytes.
       chaincodeID: fixed-asset
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      assets: 500
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          assets: 500
+          consensus: false
+    - label: get-asset-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      assets: 500
-      consensus: true
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: rich-query-evaluate-0
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches no assets in the world state database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          assets: 500
+          consensus: true
+    - label: rich-query-evaluate-0
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches no assets in the world state database.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: rich-query-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches all assets created by the calling client. Each returned asset is of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          nomatch: true
+          consensus: false
+    - label: rich-query-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 1000 bytes.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: rich-query-submit-0
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches no assets in the world state database. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          consensus: false
+    - label: rich-query-submit-0
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches no assets in the world state database. This
+        test includes involvement of the orderer, and appending to the ledger.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      nomatch: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: rich-query-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches all assets created by the calling client. Each returned asset is of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          nomatch: true
+          consensus: true
+    - label: rich-query-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 1000 bytes. This test includes involvement of
+        the orderer, and appending to the ledger.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      pagesize: '10'
-      nosetup: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/rich-query-asset.js
-  - label: range-query-evaluate-0
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no assets in the world state database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          pagesize: '10'
+          nosetup: true
+          consensus: true
+    - label: range-query-evaluate-0
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no assets in the
+        world state database.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: range-query-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-0
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no items in the world state database. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          consensus: false
+    - label: range-query-submit-0
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no items in the
+        world state database. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      nomatch: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          nomatch: true
+          consensus: true
+    - label: range-query-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes. This test includes
+        involvement of the orderer, and appending to the ledger.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      nosetup: true
-      pagesize: '10'
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          nosetup: true
+          pagesize: '10'
+          consensus: true
 monitor:
   interval: 5
-  type: ['process', 'docker']
+  type:
+    - process
+    - docker
   process:
-    processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    processes:
+      - command: node
+        arguments: fabricClientWorker.js
+        multiOutput: avg
   docker:
-    containers: ['all']
+    containers:
+      - all
 observer:
   type: local
   interval: 30

--- a/benchmarks/api/fabric/couchDB/contract/create-asset-batch.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/create-asset-batch.yaml
@@ -1,126 +1,198 @@
----
 test:
   name: create-asset-batch-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAssetsFromBatch` method, with successive rounds increasing the batch size of the assets being
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAssetsFromBatch` method, with successive rounds
+    increasing the batch size of the assets being added into the world state
+    database.
   workers:
     type: local
     number: 4
   rounds:
-  - label: create-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 5} }
-    arguments:
+    - label: create-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database at a fixed TPS.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 1 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 1 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 1
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 10 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 1
+    - label: create-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 10 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 10
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 10
+    - label: create-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 30 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 30 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 30
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 40 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 30
+    - label: create-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 40 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 40
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 50 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 40
+    - label: create-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 50 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 50
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 50
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/create-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/create-asset.yaml
@@ -1,137 +1,224 @@
----
 test:
   name: create-asset-size-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAsset` method, with successive rounds increasing the bytesize of the asset
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAsset` method, with successive rounds increasing
+    the bytesize of the asset added into the world state database.
   workers:
     type: local
     number: 5
   rounds:
-  - label: create-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database at a fixed TPS rate.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 15} }
-    arguments:
+    - label: create-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database at a fixed TPS
+        rate.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 100 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 15
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 100 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 100
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 1000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 100
+    - label: create-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 1000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+    - label: create-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 4000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 4000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 4000
+    - label: create-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 16000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 16000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 16000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-24000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 24000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 16000
+    - label: create-asset-24000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 24000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 24000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 32000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 24000
+    - label: create-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 32000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 32000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 64000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 32000
+    - label: create-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 64000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 64000
-    callback: benchmarks/api/fabric/lib/create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 64000
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/create-private-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/create-private-asset.yaml
@@ -1,128 +1,207 @@
----
 test:
   name: create-private-asset-size-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createPrivateAsset` method, with successive rounds increasing the bytesize of the asset
-    added into the Private data store.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createPrivateAsset` method, with successive rounds
+    increasing the bytesize of the asset added into the Private data store.
   workers:
     type: local
     number: 5
   rounds:
-  - label: create-private-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 8000 bytes into the Private data store at a fixed TPS rate.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 15} }
-    arguments:
+    - label: create-private-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 8000 bytes into the Private data store at a
+        fixed TPS rate.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 100 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 15
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-private-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 100 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 100
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-200
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 200 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 100
+    - label: create-private-asset-200
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 200 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 200
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-500
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 500 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 200
+    - label: create-private-asset-500
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 500 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 500
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 1000 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 500
+    - label: create-private-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 1000 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 2000 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+    - label: create-private-asset-2000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 2000 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 2000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-5000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 5000 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 2000
+    - label: create-private-asset-5000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 5000 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 5000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-10000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 10000 bytes into the Private data store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10, startingTps: 1} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 5000
+    - label: create-private-asset-10000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 10000 bytes into the Private data store.
       chaincodeID: fixed-asset
-      bytesize: 10000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+          startingTps: 1
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 10000
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/delete-asset-batch.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/delete-asset-batch.yaml
@@ -1,149 +1,233 @@
----
 test:
   name: delete-asset-batch-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `deleteAssetsFromBatch` API method. Successive rounds delete a-priori created assets of larger byte size.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `deleteAssetsFromBatch` API method. Successive rounds
+    delete a-priori created assets of larger byte size.
   workers:
     type: local
     number: 10
   rounds:
-  - label: delete-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000 # max number = (arguments.assets/assets.batchsize)
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 1 UUID that matches an asset
+        of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 4000
-      bytesize: 8000
-      batchsize: 1
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 4000
+          bytesize: 8000
+          batchsize: 1
+          consensus: true
+    - label: delete-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 10
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 10
+          consensus: true
+    - label: delete-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
+    - label: delete-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 30000
-      bytesize: 8000
-      batchsize: 30
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 30000
+          bytesize: 8000
+          batchsize: 30
+          consensus: true
+    - label: delete-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 40
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 500
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 40
+          consensus: true
+    - label: delete-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 25000
-      bytesize: 8000
-      batchsize: 50
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 30 }}
-    arguments:
+      txNumber: 500
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 25000
+          bytesize: 8000
+          batchsize: 50
+          consensus: true
+    - label: delete-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:
   type: prometheus
   interval: 10
-

--- a/benchmarks/api/fabric/couchDB/contract/delete-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/delete-asset.yaml
@@ -1,163 +1,267 @@
----
 test:
   name: delete-asset-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'deleteAsset' method. Successive rounds delete a-priori created assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'deleteAsset' method. Successive rounds delete a-priori
+    created assets of larger bytesize.
   workers:
     type: local
     number: 5
   rounds:
-  - label: delete-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 100
+        bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,4000,8000,16000,24000,32000,64000]
-      assets: 4000
-      bytesize: 100
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 4000
+            - 8000
+            - 16000
+            - 24000
+            - 32000
+            - 64000
+          assets: 4000
+          bytesize: 100
+          consensus: true
+    - label: delete-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 1000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 4000
-      bytesize: 1000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 4000
+          bytesize: 1000
+          consensus: true
+    - label: delete-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 4000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 4000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 4000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 16000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-24000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 24000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 16000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-24000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 24000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 24000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 24000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 32000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 32000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 64000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 64000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/empty-contract-1of.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/empty-contract-1of.yaml
@@ -1,91 +1,143 @@
----
 test:
   name: empty-contract-couchDB-1of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 750 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/empty-contract-2of.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/empty-contract-2of.yaml
@@ -1,91 +1,145 @@
----
 test:
   name: empty-contract-couchDB-2of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100, startingTps: 10} }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 750 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/fixed-tps-runs.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/fixed-tps-runs.yaml
@@ -1,4 +1,3 @@
----
 test:
   name: fixed-tps-runs
   description: Benchmark run to enable resource comparison for benchmarks
@@ -6,106 +5,174 @@ test:
     type: local
     number: 10
   rounds:
-  - label: create-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 100} }
-    arguments:
+    - label: create-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: get-asset-evaluate-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 100} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 20
+    - label: get-asset-evaluate-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-batch-evaluate-20-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl:  { type: fixed-rate, opts: { tps: 50} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          bytesize: 8000
+          assets: 1000
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: mixed-range-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl:  { type: fixed-rate, opts: { tps: 30} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 50
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
+    - label: mixed-range-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '20'
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '20'
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/get-asset-batch.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/get-asset-batch.yaml
@@ -1,146 +1,219 @@
----
 test:
   name: get-asset-batch-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `getAssetsFromBatch` API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `getAssetsFromBatch` API method. Successive rounds create
+    and retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-batch-evaluate-1-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+    - label: get-asset-batch-evaluate-1-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 1 UUID that matches an asset of
+        size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 1
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-10-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 1
+          consensus: false
+    - label: get-asset-batch-evaluate-10-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 10
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 10
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-30-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
+    - label: get-asset-batch-evaluate-30-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 30
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-40-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 30
+          consensus: false
+    - label: get-asset-batch-evaluate-40-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 40
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-50-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 40
+          consensus: false
+    - label: get-asset-batch-evaluate-50-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 50
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 30 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 50
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/get-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/get-asset.yaml
@@ -1,163 +1,254 @@
----
 test:
   name: get-asset-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'getAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'getAsset()' API method. Successive rounds create and
+    retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+    - label: get-asset-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 100 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 1000
-      bytesize: 100
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 1000
+          bytesize: 100
+          consensus: false
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 1000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 1000
-      bytesize: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-2000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 1000
+          bytesize: 1000
+          consensus: false
+    - label: get-asset-evaluate-2000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 2000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 2000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-4000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 2000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-4000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 4000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 4000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 4000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-16000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-16000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 16000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-32000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 16000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-32000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 32000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-64000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 32000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-64000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 64000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 64000
+          assets: 1000
+          consensus: false
+    - label: get-asset-evaluate-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes
+        at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/get-private-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/get-private-asset.yaml
@@ -1,151 +1,232 @@
----
 test:
   name: get-private-asset-ramp-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'getPrivateAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'getPrivateAsset()' API method. Successive rounds create
+    and retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-private-asset-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+    - label: get-private-asset-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 100 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,200,500,1000,2000,5000,10000]
-      assets: 1000
-      bytesize: 100
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 200 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 200
+            - 500
+            - 1000
+            - 2000
+            - 5000
+            - 10000
+          assets: 1000
+          bytesize: 100
+          consensus: false
+    - label: get-private-asset-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 200 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 1000
-      bytesize: 200
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-500
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 500 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 1000
+          bytesize: 200
+          consensus: false
+    - label: get-private-asset-evaluate-500
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 500 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 500
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 500
+          assets: 1000
+          consensus: false
+    - label: get-private-asset-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 1000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-2000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          assets: 1000
+          consensus: false
+    - label: get-private-asset-evaluate-2000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 2000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 2000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-5000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 5000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 2000
+          assets: 1000
+          consensus: false
+    - label: get-private-asset-evaluate-5000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 5000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 5000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-10000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 10000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 5000
+          assets: 1000
+          consensus: false
+    - label: get-private-asset-evaluate-10000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 10000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 10000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 10000
+          assets: 1000
+          consensus: false
+    - label: get-private-asset-evaluate-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes
+        at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/mixed-range-query-pagination.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/mixed-range-query-pagination.yaml
@@ -1,148 +1,230 @@
----
 test:
   name: fixed-asset-mixed-range-query-pagination-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'paginatedRangeQuery' method against a DB populated with mixed size assets. Successive rounds increase the pagesize of retrieved assets.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'paginatedRangeQuery' method against a DB populated with
+    mixed size assets. Successive rounds increase the pagesize of retrieved
+    assets.
   workers:
     type: local
     number: 4
   rounds:
-  - label: mixed-range-query-evaluate-10
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+    - label: mixed-range-query-evaluate-10
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 8000
-      range: 200
-      offset: 100
-      pagesize: '10'
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 8000
+          range: 200
+          offset: 100
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-50
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 50 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-50
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 50
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '50'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 100 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '50'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 100
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '100'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 200 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '100'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 200
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '200'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-300
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 500 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2  } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '200'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-300
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 500
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '300'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 10 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '300'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client at
+        a fixed TPS.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/couchDB/contract/mixed-rich-query-pagination.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/mixed-rich-query-pagination.yaml
@@ -1,127 +1,233 @@
----
 test:
   name: fixed-asset-mixed-rich-query-pagination-couchDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a CouchDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'pageinatedRichQuery' chaincode method.  Successive rounds increase the pagesize of retrieved assets.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'pageinatedRichQuery' chaincode method.  Successive rounds
+    increase the pagesize of retrieved assets.
   workers:
     type: local
     number: 4
   rounds:
-  - label: mixed-rich-query-evaluate-10
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`.  This method performs a paginated rich query, with a passed pagesize of 10 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+    - label: mixed-rich-query-evaluate-10
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`.  This
+        method performs a paginated rich query, with a passed pagesize of 10 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000]
-      assets: 8000
-      pagesize: '10'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 20 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          assets: 8000
+          pagesize: '10'
+          consensus: false
+    - label: mixed-rich-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 20 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-50
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 50 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '20'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-50
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 50 and
+        query string that matches all assets created by the calling client. Each
+        returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '50'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 100 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '50'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 100
+        and query string that matches all assets created by the calling client.
+        Each returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '100'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 200 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '100'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 200
+        and query string that matches all assets created by the calling client.
+        Each returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '200'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
-  - label: mixed-rich-query-evaluate-500
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRichQuery`. This method performs a paginated rich query, with a passed pagesize of 500 and query string that matches all assets created by the calling client. Each returned asset is of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5, startingTps: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '200'
+          nosetup: true
+          consensus: false
+    - label: mixed-rich-query-evaluate-500
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRichQuery`. This
+        method performs a paginated rich query, with a passed pagesize of 500
+        and query string that matches all assets created by the calling client.
+        Each returned asset is of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000]
-      pagesize: '500'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+          startingTps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-rich-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+          pagesize: '500'
+          nosetup: true
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/base.yaml
+++ b/benchmarks/api/fabric/levelDB/base/base.yaml
@@ -1,125 +1,219 @@
----
 test:
   name: fixed-asset-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round flexes a single chaincode method, and includes a null-operation to act as a performance cost baseline.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes a single chaincode method, and includes a null-operation to act
+    as a performance cost baseline.
   workers:
     type: local
     number: 4
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: create-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `create`, which inserts an Asset of size 1000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
+    - label: create-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `create`, which inserts an
+        Asset of size 1000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes. 
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: true
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: range-query-evaluate-0
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no items in the world state database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: true
+    - label: range-query-evaluate-0
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no items in the
+        world state database.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: range-query-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-0
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no items in the world state database. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          consensus: false
+    - label: range-query-submit-0
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no items in the
+        world state database. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      nomatch: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          nomatch: true
+          consensus: true
+    - label: range-query-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes. This test includes
+        involvement of the orderer, and appending to the ledger.
       chaincodeID: fixed-asset-base
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          consensus: true
 monitor:
   interval: 5
-  type: ['process', 'docker']
+  type:
+    - process
+    - docker
   process:
-    processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    processes:
+      - command: node
+        arguments: fabricClientWorker.js
+        multiOutput: avg
   docker:
-    containers: ['all']
+    containers:
+      - all

--- a/benchmarks/api/fabric/levelDB/base/create-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/base/create-asset-batch.yaml
@@ -1,126 +1,198 @@
----
 test:
   name: create-asset-batch-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAssetsFromBatch` method, with successive rounds increasing the batchsize of the assets being
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAssetsFromBatch` method, with successive rounds
+    increasing the batchsize of the assets being added into the world state
+    database.
   workers:
     type: local
     number: 4
   rounds:
-  - label: create-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 5} }
-    arguments:
+    - label: create-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database at a fixed TPS.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 1 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 1 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 1
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 10 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 1
+    - label: create-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 10 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 10
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 10
+    - label: create-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 30 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 30 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 30
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 40 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 30
+    - label: create-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 40 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 40
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 50 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 40
+    - label: create-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 50 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-      batchsize: 50
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+          batchsize: 50
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/create-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/base/create-asset.yaml
@@ -1,128 +1,200 @@
----
 test:
   name: create-asset-size-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAsset` method, with successive rounds increasing the bytesize of the asset
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAsset` method, with successive rounds increasing
+    the bytesize of the asset added into the world state database.
   workers:
     type: local
     number: 10
   rounds:
-  - label: create-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database at a fixed TPS rate.
-    chaincodeID: fixed-asset-base
-    txDuration: 30
-    rateControl:  { type: fixed-rate,  opts: { tps: 15} }
-    arguments:
+    - label: create-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database at a fixed TPS
+        rate.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 100 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 30
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 15
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+    - label: create-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 100 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 100
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 2000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 100
+    - label: create-asset-2000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 2000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 2000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 2000
+    - label: create-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 4000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 4000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 4000
+    - label: create-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 16000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 8000
+    - label: create-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 16000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 16000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 32000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 16000
+    - label: create-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 32000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 32000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 64000 bytes into the World State database.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 32000
+    - label: create-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 64000 bytes into the World State database.
       chaincodeID: fixed-asset-base
-      bytesize: 64000
-    callback: benchmarks/api/fabric/lib/create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          bytesize: 64000
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/delete-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/base/delete-asset-batch.yaml
@@ -1,149 +1,233 @@
----
 test:
   name: delete-asset-batch-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `deleteAssetsFromBatch` API method. Successive rounds delete a-priori created assets of larger byte size.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `deleteAssetsFromBatch` API method. Successive rounds
+    delete a-priori created assets of larger byte size.
   workers:
     type: local
     number: 10
   rounds:
-  - label: delete-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000 # max number = (arguments.assets/assets.batchsize)
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 1 UUID that matches an asset
+        of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 4000
-      bytesize: 8000
-      batchsize: 1
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 4000
+          bytesize: 8000
+          batchsize: 1
+          consensus: true
+    - label: delete-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 10
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 10
+          consensus: true
+    - label: delete-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
+    - label: delete-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 30000
-      bytesize: 8000
-      batchsize: 30
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 30000
+          bytesize: 8000
+          batchsize: 30
+          consensus: true
+    - label: delete-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 40
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 500
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 40
+          consensus: true
+    - label: delete-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 25000
-      bytesize: 8000
-      batchsize: 50
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 30 }}
-    arguments:
+      txNumber: 500
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 25000
+          bytesize: 8000
+          batchsize: 50
+          consensus: true
+    - label: delete-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:
   type: prometheus
   interval: 10
-

--- a/benchmarks/api/fabric/levelDB/base/delete-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/base/delete-asset.yaml
@@ -1,163 +1,267 @@
----
 test:
   name: delete-asset-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'deleteAsset' method. Successive rounds delete a-priori created assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'deleteAsset' method. Successive rounds delete a-priori
+    created assets of larger bytesize.
   workers:
     type: local
     number: 5
   rounds:
-  - label: delete-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 100
+        bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 4000
-      bytesize: 100
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 4000
+          bytesize: 100
+          consensus: true
+    - label: delete-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 1000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 4000
-      bytesize: 1000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 4000
+          bytesize: 1000
+          consensus: true
+    - label: delete-asset-2000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 2000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 2000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 2000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 4000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 4000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 4000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 16000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 16000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 32000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 32000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 64000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 64000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes at a fixed TPS.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/empty-contract-1of.yaml
+++ b/benchmarks/api/fabric/levelDB/base/empty-contract-1of.yaml
@@ -1,91 +1,143 @@
----
 test:
   name: empty-contract-levelDB-1of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 750} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 350} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/empty-contract-2of.yaml
+++ b/benchmarks/api/fabric/levelDB/base/empty-contract-2of.yaml
@@ -1,91 +1,143 @@
----
 test:
   name: empty-contract-levelDB-2of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 750} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 350} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset-base
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/get-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/base/get-asset-batch.yaml
@@ -1,146 +1,220 @@
----
 test:
   name: get-asset-batch-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the `getAssetsFromBatch` API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `getAssetsFromBatch` API method. Successive rounds create
+    and retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-batch-evaluate-1-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+    - label: get-asset-batch-evaluate-1-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 1 UUID that matches an asset of
+        size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 1
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-10-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 1
+          consensus: false
+    - label: get-asset-batch-evaluate-10-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 10
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 10
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-30-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
+    - label: get-asset-batch-evaluate-30-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 30
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-40-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 30
+          consensus: false
+    - label: get-asset-batch-evaluate-40-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 40
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-50-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 40
+          consensus: false
+    - label: get-asset-batch-evaluate-50-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 50
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl:  { type: fixed-rate,  opts: { tps: 30} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 50
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/get-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/base/get-asset.yaml
@@ -1,164 +1,255 @@
----
 test:
   name: get-asset-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'getAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'getAsset()' API method. Successive rounds create and
+    retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+    - label: get-asset-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 100 bytes.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 1000
-      bytesize: 100
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 1000
+          bytesize: 100
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 1000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-2000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-2000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 2000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 2000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-4000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 2000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-4000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 4000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 4000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 4000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-16000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-16000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 16000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-32000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 16000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-32000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 32000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-64000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 32000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-64000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 64000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 64000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes
+        at a fixed TPS.
       chaincodeID: fixed-asset-base
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/base/mixed-range-query-pagination.yaml
+++ b/benchmarks/api/fabric/levelDB/base/mixed-range-query-pagination.yaml
@@ -1,148 +1,230 @@
----
 test:
   name: fixed-asset-mixed-range-query-pagination-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'paginatedRangeQuery' method against a DB populated with mixed size assets. Successive rounds increase the pagesize of retrieved assets.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'paginatedRangeQuery' method against a DB populated with
+    mixed size assets. Successive rounds increase the pagesize of retrieved
+    assets.
   workers:
     type: local
     number: 4
   rounds:
-  - label: mixed-range-query-evaluate-10
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
-    arguments:
+    - label: mixed-range-query-evaluate-10
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 8000
-      range: 200
-      offset: 100
-      pagesize: '10'      
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 8000
+          range: 200
+          offset: 100
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-50
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 50 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-50
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 50
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '50'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 100 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '50'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 100
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '100'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 200 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '100'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 200
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '200'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-300
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 500 and a range keys that bound 500 assets created by the calling client.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '200'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-300
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 500
+        and a range keys that bound 500 assets created by the calling client.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '300'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client at a fixed TPS.
-    chaincodeID: fixed-asset-base
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '300'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client at
+        a fixed TPS.
       chaincodeID: fixed-asset-base
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset-base
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/base.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/base.yaml
@@ -1,125 +1,219 @@
----
 test:
   name: fixed-asset-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round flexes a single chaincode method, and includes a null-operation to act as a performance cost baseline.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes a single chaincode method, and includes a null-operation to act
+    as a performance cost baseline.
   workers:
     type: local
     number: 4
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: create-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `create`, which inserts an Asset of size 1000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
+    - label: create-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `create`, which inserts an
+        Asset of size 1000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes. 
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a `getState()` operation for a passed UUID, retrieving as asset of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a `getState()` operation for a passed UUID, retrieving as asset
+        of size 1000 bytes. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: true
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: range-query-evaluate-0
-    description: Test a evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no items in the world state database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: true
+    - label: range-query-evaluate-0
+      description: >-
+        Test a evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no items in the
+        world state database.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: range-query-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-0
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query that matches no items in the world state database. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          consensus: false
+    - label: range-query-submit-0
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query that matches no items in the
+        world state database. This test includes involvement of the orderer, and
+        appending to the ledger.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      nomatch: true
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
-  - label: range-query-submit-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client. Each returned asset is of size 1000 bytes. This test includes involvement of the orderer, and appending to the ledger.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 15, startingTps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          nomatch: true
+          consensus: true
+    - label: range-query-submit-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
+        Each returned asset is of size 1000 bytes. This test includes
+        involvement of the orderer, and appending to the ledger.
       chaincodeID: fixed-asset
-      bytesize: 1000
-      range: 200
-      offset: 100
-      assets: 0
-      pagesize: '10'
-      consensus: true
-    callback: benchmarks/api/fabric/lib/range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 15
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+          range: 200
+          offset: 100
+          assets: 0
+          pagesize: '10'
+          consensus: true
 monitor:
   interval: 5
-  type: ['process', 'docker']
+  type:
+    - process
+    - docker
   process:
-    processes: [{ command: 'node', arguments: 'fabricClientWorker.js', multiOutput: 'avg' }]
+    processes:
+      - command: node
+        arguments: fabricClientWorker.js
+        multiOutput: avg
   docker:
-    containers: ['all']
+    containers:
+      - all

--- a/benchmarks/api/fabric/levelDB/contract/create-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/create-asset-batch.yaml
@@ -1,126 +1,198 @@
----
 test:
   name: create-asset-batch-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAssetsFromBatch` method, with successive rounds increasing the batchsize of the assets being
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAssetsFromBatch` method, with successive rounds
+    increasing the batchsize of the assets being added into the world state
+    database.
   workers:
     type: local
     number: 4
   rounds:
-  - label: create-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 5} }
-    arguments:
+    - label: create-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database at a fixed TPS.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 1 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 1 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 1
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 10 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 1
+    - label: create-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 10 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 10
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 20 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 10
+    - label: create-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 20 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 20
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 30 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 20
+    - label: create-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 30 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 30
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 40 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 30
+    - label: create-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 40 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 40
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
-  - label: create-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which inserts a batch of 50 assets of size 8k bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 5} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 40
+    - label: create-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts a batch of 50 assets of size 8k bytes into the World State
+        database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-      batchsize: 50
-    callback: benchmarks/api/fabric/lib/batch-create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 5
+      workload:
+        module: benchmarks/api/fabric/lib/batch-create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+          batchsize: 50
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/create-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/create-asset.yaml
@@ -1,128 +1,200 @@
----
 test:
   name: create-asset-size-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createAsset` method, with successive rounds increasing the bytesize of the asset
-    added into the world state database.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createAsset` method, with successive rounds increasing
+    the bytesize of the asset added into the world state database.
   workers:
     type: local
     number: 10
   rounds:
-  - label: create-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database at a fixed TPS rate.
-    chaincodeID: fixed-asset
-    txDuration: 30
-    rateControl:  { type: fixed-rate,  opts: { tps: 15} }
-    arguments:
+    - label: create-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database at a fixed TPS
+        rate.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 100 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 30
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 15
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 100 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 100
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 1000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 100
+    - label: create-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 1000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 4000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+    - label: create-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 4000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 4000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 8000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 4000
+    - label: create-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 8000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 16000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 16000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 16000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 32000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 16000
+    - label: create-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 32000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 32000
-    callback: benchmarks/api/fabric/lib/create-asset.js
-  - label: create-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createAsset`, which inserts an asset of size 64000 bytes into the World State database.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 32000
+    - label: create-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAsset`, which inserts
+        an asset of size 64000 bytes into the World State database.
       chaincodeID: fixed-asset
-      bytesize: 64000
-    callback: benchmarks/api/fabric/lib/create-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 64000
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/create-private-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/create-private-asset.yaml
@@ -1,128 +1,200 @@
----
 test:
   name: create-private-asset-size-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `createPrivateAsset` method, with successive rounds increasing the bytesize of the private asset
-    added into the Private Store
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `createPrivateAsset` method, with successive rounds
+    increasing the bytesize of the private asset added into the Private Store
   workers:
     type: local
     number: 10
   rounds:
-  - label: create-private-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 8000 bytes into the Private Store at a fixed TPS rate.
-    chaincodeID: fixed-asset
-    txDuration: 30
-    rateControl:  { type: fixed-rate,  opts: { tps: 15} }
-    arguments:
+    - label: create-private-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 8000 bytes into the Private Store at a fixed
+        TPS rate.
       chaincodeID: fixed-asset
-      bytesize: 8000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 100 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 30
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 15
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 8000
+    - label: create-private-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 100 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 100
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-200
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 200 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 100
+    - label: create-private-asset-200
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 200 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 200
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-500
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 500 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 200
+    - label: create-private-asset-500
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 500 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 500
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 1000 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 500
+    - label: create-private-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 1000 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 1000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-2000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 2000 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 1000
+    - label: create-private-asset-2000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 2000 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 2000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-5000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 5000 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 2000
+    - label: create-private-asset-5000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 5000 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 5000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
-  - label: create-private-asset-10000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `createPrivateAsset`, which inserts an asset of size 10000 bytes into the Private Store.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 10 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 5000
+    - label: create-private-asset-10000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createPrivateAsset`, which
+        inserts an asset of size 10000 bytes into the Private Store.
       chaincodeID: fixed-asset
-      bytesize: 10000
-    callback: benchmarks/api/fabric/lib/create-private-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/api/fabric/lib/create-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          bytesize: 10000
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/delete-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/delete-asset-batch.yaml
@@ -1,149 +1,233 @@
----
 test:
   name: delete-asset-batch-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the `deleteAssetsFromBatch` API method. Successive rounds delete a-priori created assets of larger byte size.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `deleteAssetsFromBatch` API method. Successive rounds
+    delete a-priori created assets of larger byte size.
   workers:
     type: local
     number: 10
   rounds:
-  - label: delete-asset-batch-1-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000 # max number = (arguments.assets/assets.batchsize)
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-batch-1-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 1 UUID that matches an asset
+        of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 4000
-      bytesize: 8000
-      batchsize: 1
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-10-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 4000
+          bytesize: 8000
+          batchsize: 1
+          consensus: true
+    - label: delete-asset-batch-10-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 10
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 10
+          consensus: true
+    - label: delete-asset-batch-20-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-30-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
+    - label: delete-asset-batch-30-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 30000
-      bytesize: 8000
-      batchsize: 30
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-40-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 1000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 30000
+          bytesize: 8000
+          batchsize: 30
+          consensus: true
+    - label: delete-asset-batch-40-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 40000
-      bytesize: 8000
-      batchsize: 40
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-50-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 500
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 1000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 40000
+          bytesize: 8000
+          batchsize: 40
+          consensus: true
+    - label: delete-asset-batch-50-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 25000
-      bytesize: 8000
-      batchsize: 50
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
-  - label: delete-asset-batch-20-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This method performs a deleteState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 30 }}
-    arguments:
+      txNumber: 500
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 25000
+          bytesize: 8000
+          batchsize: 50
+          consensus: true
+    - label: delete-asset-batch-20-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAssetsFromBatch`. This
+        method performs a deleteState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 80000
-      bytesize: 8000
-      batchsize: 20
-      consensus: true
-    callback: benchmarks/api/fabric/lib/batch-delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 80000
+          bytesize: 8000
+          batchsize: 20
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:
   type: prometheus
   interval: 10
-

--- a/benchmarks/api/fabric/levelDB/contract/delete-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/delete-asset.yaml
@@ -1,163 +1,267 @@
----
 test:
   name: delete-asset-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'deleteAsset' method. Successive rounds delete a-priori created assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'deleteAsset' method. Successive rounds delete a-priori
+    created assets of larger bytesize.
   workers:
     type: local
     number: 5
   rounds:
-  - label: delete-asset-100
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+    - label: delete-asset-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 100
+        bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,4000,8000,16000,24000,32000,64000]
-      assets: 4000
-      bytesize: 100
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-1000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 4000
+            - 8000
+            - 16000
+            - 24000
+            - 32000
+            - 64000
+          assets: 4000
+          bytesize: 100
+          consensus: true
+    - label: delete-asset-1000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 1000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 4000
-      bytesize: 1000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-4000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 4000
+          bytesize: 1000
+          consensus: true
+    - label: delete-asset-4000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 4000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 4000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 4000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-16000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-16000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 16000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-24000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 24000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 16000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-24000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 24000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 24000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-32000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 24000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-32000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 32000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-64000
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 20, startingTps: 10} }
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 32000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-64000
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 64000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
-  - label: delete-asset-8000-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `deleteAsset`. This method performs a deleteState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txNumber: 4000
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txNumber: 4000
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 64000
+          assets: 4000
+          consensus: true
+    - label: delete-asset-8000-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 8000
+        bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 4000
-      consensus: true
-    callback: benchmarks/api/fabric/lib/delete-asset.js
+      txNumber: 4000
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/delete-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 4000
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/empty-contract-1of.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/empty-contract-1of.yaml
@@ -1,91 +1,143 @@
----
 test:
   name: empty-contract-levelDB-1of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 750} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 350} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/empty-contract-2of.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/empty-contract-2of.yaml
@@ -1,91 +1,143 @@
----
 test:
   name: empty-contract-levelDB-2of
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round flexes the `emptyContract` method. Rounds run for evaluate and submit Gateway routes.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round flexes the `emptyContract` method. Rounds run for evaluate and submit
+    Gateway routes.
   workers:
     type: local
     number: 10
   rounds:
-  - label: empty-contract-evaluate
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+    - label: empty-contract-evaluate
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: { unfinished_per_client: 100 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-evaluate-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `emptyContract`, which immediately returns a null response. This represents the fastest possible round trip time for an evaluateTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 750} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 100
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
+    - label: empty-contract-evaluate-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `emptyContract`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for an evaluateTransaction() method that does
+        not touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: false
-    callback: benchmarks/api/fabric/lib/empty-contract.js
-  - label: empty-contract-submit-fixed-tps
-    description: Test a submitTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `nullResponse`, which immediately returns a null response. This represents the fastest possible round trip time for a submitTransaction() method that does not touch the world state or perform any action.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 350} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 750
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: false
+    - label: empty-contract-submit-fixed-tps
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `nullResponse`, which
+        immediately returns a null response. This represents the fastest
+        possible round trip time for a submitTransaction() method that does not
+        touch the world state or perform any action.
       chaincodeID: fixed-asset
-      consensus: true
-    callback: benchmarks/api/fabric/lib/empty-contract.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/empty-contract.js
+        arguments:
+          chaincodeID: fixed-asset
+          consensus: true
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/get-asset-batch.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/get-asset-batch.yaml
@@ -1,146 +1,220 @@
----
 test:
   name: get-asset-batch-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the `getAssetsFromBatch` API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the `getAssetsFromBatch` API method. Successive rounds create
+    and retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-batch-evaluate-1-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 1 UUID that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+    - label: get-asset-batch-evaluate-1-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 1 UUID that matches an asset of
+        size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 1
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-10-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 10 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 1
+          consensus: false
+    - label: get-asset-batch-evaluate-10-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 10 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [8000]
-      assets: 8000
-      bytesize: 8000
-      batchsize: 10
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 8000
+          assets: 8000
+          bytesize: 8000
+          batchsize: 10
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-30-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 30 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
+    - label: get-asset-batch-evaluate-30-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 30 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 30
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-40-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 40 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 30
+          consensus: false
+    - label: get-asset-batch-evaluate-40-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 40 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 40
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-50-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 50 UUIDs that each match an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 20 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 40
+          consensus: false
+    - label: get-asset-batch-evaluate-50-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 50 UUIDs that each match an
+        asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 50
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
-  - label: get-asset-batch-evaluate-20-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This method performs a getState on a batch of 20 UUIDs that each match an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl:  { type: fixed-rate,  opts: { tps: 30} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 20
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 50
+          consensus: false
+    - label: get-asset-batch-evaluate-20-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAssetsFromBatch`. This
+        method performs a getState on a batch of 20 UUIDs that each match an
+        asset of size 8000 bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      assets: 8000
-      bytesize: 8000
-      batchsize: 20
-      consensus: false
-    callback: benchmarks/api/fabric/lib/batch-get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 30
+      workload:
+        module: benchmarks/api/fabric/lib/batch-get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          assets: 8000
+          bytesize: 8000
+          batchsize: 20
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/get-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/get-asset.yaml
@@ -1,164 +1,255 @@
----
 test:
   name: get-asset-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'getAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'getAsset()' API method. Successive rounds create and
+    retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-asset-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+    - label: get-asset-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 100 bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 1000
-      bytesize: 100
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 1000
+          bytesize: 100
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 1000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-2000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-2000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 2000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 2000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-4000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 4000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 2000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-4000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 4000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 4000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 4000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-8000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-16000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 16000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-16000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 16000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 16000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-32000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 32000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 16000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-32000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 32000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 32000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-64000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 64000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 32000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-64000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 64000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 64000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
-  - label: get-asset-evaluate-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getAsset`. This method performs a getState on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 64000
+          uuid: '500'
+          consensus: false
+    - label: get-asset-evaluate-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getAsset`. This method
+        performs a getState on an item that matches an asset of size 8000 bytes
+        at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/get-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/get-private-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/get-private-asset.yaml
@@ -1,152 +1,239 @@
----
 test:
   name: get-private-asset-ramp-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'getPrivateAsset()' API method. Successive rounds create and retrieve assets of larger bytesize.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'getPrivateAsset()' API method. Successive rounds create
+    and retrieve assets of larger bytesize.
   workers:
     type: local
     number: 10
   rounds:
-  - label: get-private-asset-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 100 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+    - label: get-private-asset-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 100
+        bytes.
       chaincodeID: fixed-asset
-      create_sizes: [100,200,500,1000,2000,5000,10000]
-      assets: 1000
-      bytesize: 100
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 200 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 200
+            - 500
+            - 1000
+            - 2000
+            - 5000
+            - 10000
+          assets: 1000
+          bytesize: 100
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 200
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 200
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-500
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 500 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 200
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-500
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 500
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 500
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-1000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 1000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 500
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-1000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 1000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 1000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-2000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 2000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 1000
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-2000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 2000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 2000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-5000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 5000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 2000
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-5000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 5000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 5000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-10000
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 10000 bytes.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 50 } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 5000
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-10000
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 10000
+        bytes.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 10000
-      uuid: '500'
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
-  - label: get-private-asset-evaluate-8000-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `getPrivateAsset`. This method performs a getPrivateData on an item that matches an asset of size 8000 bytes at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate, opts: { tps: 350 }}
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 50
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 10000
+          uuid: '500'
+          consensus: false
+    - label: get-private-asset-evaluate-8000-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
+        performs a getPrivateData on an item that matches an asset of size 8000
+        bytes at a fixed TPS.
       chaincodeID: fixed-asset
-      nosetup: true
-      bytesize: 8000
-      assets: 1000
-      consensus: false
-    callback: benchmarks/api/fabric/lib/get-private-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 350
+      workload:
+        module: benchmarks/api/fabric/lib/get-private-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          nosetup: true
+          bytesize: 8000
+          assets: 1000
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/api/fabric/levelDB/contract/mixed-range-query-pagination.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/mixed-range-query-pagination.yaml
@@ -1,148 +1,230 @@
----
 test:
   name: fixed-asset-mixed-range-query-pagination-levelDB
-  description: This is a duration based benchmark targeting a Hyperledger Fabric network with a LevelDB world state database using the `fixed-asset` NodeJS chaincode contract that is interacted with via 
-    a Fabric-SDK-Node Gateway. Each test round invokes the 'paginatedRangeQuery' method against a DB populated with mixed size assets. Successive rounds increase the pagesize of retrieved assets.
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round invokes the 'paginatedRangeQuery' method against a DB populated with
+    mixed size assets. Successive rounds increase the pagesize of retrieved
+    assets.
   workers:
     type: local
     number: 4
   rounds:
-  - label: mixed-range-query-evaluate-10
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 10 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
-    arguments:
+    - label: mixed-range-query-evaluate-10
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 10
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      create_sizes: [100,1000,2000,4000,8000,16000,32000,64000]
-      assets: 8000
-      range: 200
-      offset: 100
-      pagesize: '10'      
-      nomatch: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          create_sizes:
+            - 100
+            - 1000
+            - 2000
+            - 4000
+            - 8000
+            - 16000
+            - 32000
+            - 64000
+          assets: 8000
+          range: 200
+          offset: 100
+          pagesize: '10'
+          nomatch: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-50
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 50 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {   unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-50
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 50
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '50'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-100
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 100 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '50'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-100
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 100
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '100'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-200
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 200 and a range keys that bound 200 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '100'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-200
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 200
+        and a range keys that bound 200 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '200'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-300
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 500 and a range keys that bound 500 assets created by the calling client.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-backlog,  opts: {  unfinished_per_client: 2   } }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '200'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-300
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 500
+        and a range keys that bound 500 assets created by the calling client.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '300'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
-  - label: mixed-range-query-evaluate-20-fixed-tps
-    description: Test an evaluateTransaction() Gateway method against the NodeJS `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This method performs a paginated range query, with a passed pagesize of 20 and a range keys that bound 200 assets created by the calling client at a fixed TPS.
-    chaincodeID: fixed-asset
-    txDuration: 300
-    rateControl: { type: fixed-rate,  opts: { tps: 10} }
-    arguments:
+      txDuration: 300
+      rateControl:
+        type: fixed-backlog
+        opts:
+          unfinished_per_client: 2
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '300'
+          nosetup: true
+          consensus: false
+    - label: mixed-range-query-evaluate-20-fixed-tps
+      description: >-
+        Test an evaluateTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `paginatedRangeQuery`. This
+        method performs a paginated range query, with a passed pagesize of 20
+        and a range keys that bound 200 assets created by the calling client at
+        a fixed TPS.
       chaincodeID: fixed-asset
-      range: 200
-      offset: 100
-      pagesize: '20'
-      nosetup: true
-      consensus: false
-    callback: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+      txDuration: 300
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 10
+      workload:
+        module: benchmarks/api/fabric/lib/mixed-range-query-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          range: 200
+          offset: 100
+          pagesize: '20'
+          nosetup: true
+          consensus: false
 monitor:
   type:
-  - prometheus
-  prometheus:  
-    url: "http://localhost:9090"
-    push_url: "http://localhost:9091"
+    - prometheus
+  prometheus:
+    url: 'http://localhost:9090'
+    push_url: 'http://localhost:9091'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter, ca.org1.example.com, ca.org2.example.com]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
+        - ca.org1.example.com
+        - ca.org2.example.com
       include:
         Avg Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 0.000001
         CPU (%):
-          query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: avg
           multiplier: 100
         Network In (MB):
-          query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Network Out (MB):
-          query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+          query: >-
+            sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by
+            (name)
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Write (MB):
-          query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
         Disc Read (MB):
-          query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+          query: 'sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: sum
           multiplier: 0.000001
 observer:

--- a/benchmarks/samples/burrow/config.yaml
+++ b/benchmarks/samples/burrow/config.yaml
@@ -1,43 +1,47 @@
----
 test:
   name: simple
-  description: This is an example benchmark for caliper, to test the backend DLT's
-    performance with simple account transfer & querying transactions& invoking transactions
+  description: >-
+    This is an example benchmark for caliper, to test the backend DLT's
+    performance with simple account transfer & querying transactions& invoking
+    transactions
   workers:
     type: local
     number: 1
   rounds:
-  - label: account transfer
-    description: Test description for transfering money between accounts
-    txNumber: 2
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 1
-    arguments:
-      money: 1000,
-      toAccount: "2F186F827E9DC641D6D08C98E55DA631556DDB0D"
-    callback: benchmarks/samples/burrow/transfer.js
-  - label: contract invoke
-    description: Test description for the invoke performance of the deployed chaincode
-    txNumber: 2
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 1
-    callback: benchmarks/samples/burrow/invoke.js
-  - label: contract query
-    description: Test description for the query performance of the deployed chaincode
-    txNumber: 2
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 1
-    callback: benchmarks/samples/burrow/query.js
+    - label: account transfer
+      description: Test description for transfering money between accounts
+      txNumber: 2
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 1
+      workload:
+        module: benchmarks/samples/burrow/transfer.js
+        arguments:
+          money: '1000,'
+          toAccount: 2F186F827E9DC641D6D08C98E55DA631556DDB0D
+    - label: contract invoke
+      description: Test description for the invoke performance of the deployed chaincode
+      txNumber: 2
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 1
+      workload:
+        module: benchmarks/samples/burrow/invoke.js
+    - label: contract query
+      description: Test description for the query performance of the deployed chaincode
+      txNumber: 2
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 1
+      workload:
+        module: benchmarks/samples/burrow/query.js
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/samples/fabric/fabcar/config.yaml
+++ b/benchmarks/samples/fabric/fabcar/config.yaml
@@ -1,72 +1,61 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   workers:
     type: local
     number: 5
   rounds:
-  - label: Change car owner.
-    txDuration:
-    - 30
-    rateControl:
-    - type: fixed-backlog
-      opts:
-        unfinished_per_client: 5
-    arguments:
-      assets: 1000
-    callback: benchmarks/samples/fabric/fabcar/changeCarOwner.js
-  - label: Query all cars.
-    txDuration:
-    - 30
-    rateControl:
-    - type: fixed-backlog
-      opts:
-        unfinished_per_client: 5
-    arguments:
-      assets: 1000
-      startKey: '1'
-      endKey: '50'
-    callback: benchmarks/samples/fabric/fabcar/queryAllCars.js
-  - label: Query a car.
-    txDuration:
-    - 30
-    rateControl:
-    - type: fixed-backlog
-      opts:
-        unfinished_per_client: 5
-    arguments:
-      assets: 1000
-    callback: benchmarks/samples/fabric/fabcar/queryCar.js
-  - label: Create a car.
-    txDuration:
-    - 30
-    rateControl:
-    - type: fixed-backlog
-      opts:
-        unfinished_per_client: 5
-    callback: benchmarks/samples/fabric/fabcar/createCar.js
+    - label: Change car owner.
+      txDuration:
+        - 30
+      rateControl:
+        - type: fixed-backlog
+          opts:
+            unfinished_per_client: 5
+      workload:
+        module: benchmarks/samples/fabric/fabcar/changeCarOwner.js
+        arguments:
+          assets: 1000
+    - label: Query all cars.
+      txDuration:
+        - 30
+      rateControl:
+        - type: fixed-backlog
+          opts:
+            unfinished_per_client: 5
+      workload:
+        module: benchmarks/samples/fabric/fabcar/queryAllCars.js
+        arguments:
+          assets: 1000
+          startKey: '1'
+          endKey: '50'
+    - label: Query a car.
+      txDuration:
+        - 30
+      rateControl:
+        - type: fixed-backlog
+          opts:
+            unfinished_per_client: 5
+      workload:
+        module: benchmarks/samples/fabric/fabcar/queryCar.js
+        arguments:
+          assets: 1000
+    - label: Create a car.
+      txDuration:
+        - 30
+      rateControl:
+        - type: fixed-backlog
+          opts:
+            unfinished_per_client: 5
+      workload:
+        module: benchmarks/samples/fabric/fabcar/createCar.js
 monitor:
   type:
-  - docker
-  - process
+    - docker
+    - process
   docker:
     name:
-    - all
+      - all
   process:
-  - command: node
-    arguments: fabricClientWorker.js
-    multiOutput: avg
+    - command: node
+      arguments: fabricClientWorker.js
+      multiOutput: avg
   interval: 1

--- a/benchmarks/samples/fabric/marbles/config-prometheus.yaml
+++ b/benchmarks/samples/fabric/marbles/config-prometheus.yaml
@@ -1,18 +1,3 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   name: Marble Benchmarking
   description: Perf test marbles
@@ -20,65 +5,82 @@ test:
     type: local
     number: 1
   rounds:
-  - label: init
-    description: Create marbles. Lots of them. So many marbles that if you lost them, you would still be sane.
-    txDuration: 20
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 5
-    callback: benchmarks/samples/fabric/marbles/init.js
-  - label: query
-    description: Query marbles. Query them until you are bored of querying them. Then query them some more.
-    txDuration: 20
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 5
-    callback: benchmarks/samples/fabric/marbles/query.js
+    - label: init
+      description: >-
+        Create marbles. Lots of them. So many marbles that if you lost them, you
+        would still be sane.
+      txDuration: 20
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/samples/fabric/marbles/init.js
+    - label: query
+      description: >-
+        Query marbles. Query them until you are bored of querying them. Then
+        query them some more.
+      txDuration: 20
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/samples/fabric/marbles/query.js
 observer:
   type: prometheus
   interval: 1
 monitor:
   type:
-  - docker
-  - process
-  - prometheus
+    - docker
+    - process
+    - prometheus
   docker:
     containers:
-    - all
+      - all
     charting:
       polar:
-        metrics: [all]
+        metrics:
+          - all
       bar:
-        metrics: [Memory(max)]
+        metrics:
+          - Memory(max)
   process:
-    processes:    
-    - command: node
-      arguments: fabricClientWorker.js
-      multiOutput: avg
+    processes:
+      - command: node
+        arguments: fabricClientWorker.js
+        multiOutput: avg
     charting:
       bar:
-        metrics: [all]
+        metrics:
+          - all
   prometheus:
-    push_url: "http://localhost:9091"
-    url: "http://localhost:9090"
+    push_url: 'http://localhost:9091'
+    url: 'http://localhost:9090'
     metrics:
-      ignore: [prometheus, pushGateway, cadvisor, grafana, node-exporter]
+      ignore:
+        - prometheus
+        - pushGateway
+        - cadvisor
+        - grafana
+        - node-exporter
       include:
         Endorse Time (s):
-          query: rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[5m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[5m])
+          query: >-
+            rate(endorser_propsal_duration_sum{chaincode="marbles:v0"}[5m])/rate(endorser_propsal_duration_count{chaincode="marbles:v0"}[5m])
           step: 1
-          label: instance		
+          label: instance
           statistic: avg
         Max Memory (MB):
-          query: sum(container_memory_rss{name=~".+"}) by (name)
+          query: 'sum(container_memory_rss{name=~".+"}) by (name)'
           step: 10
-          label: name		
+          label: name
           statistic: max
           multiplier: 0.000001
     charting:
       polar:
-        metrics: [Max Memory (MB)]
+        metrics:
+          - Max Memory (MB)
       bar:
-        metrics: [all]
+        metrics:
+          - all

--- a/benchmarks/samples/fabric/marbles/config.yaml
+++ b/benchmarks/samples/fabric/marbles/config.yaml
@@ -1,42 +1,28 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   workers:
     type: local
     number: 5
   rounds:
-  - label: init
-    txNumber: 500
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 25
-    callback: benchmarks/samples/fabric/marbles/init.js
-  - label: query
-    txDuration: 15
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 5
-    callback: benchmarks/samples/fabric/marbles/query.js
+    - label: init
+      txNumber: 500
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 25
+      workload:
+        module: benchmarks/samples/fabric/marbles/init.js
+    - label: query
+      txDuration: 15
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 5
+      workload:
+        module: benchmarks/samples/fabric/marbles/query.js
 monitor:
   type:
-  - docker
+    - docker
   docker:
     names:
-    - all
-  
+      - all
   interval: 1

--- a/benchmarks/samples/fisco-bcos/generate_txs_in_advance/config.yaml
+++ b/benchmarks/samples/fisco-bcos/generate_txs_in_advance/config.yaml
@@ -1,18 +1,3 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   name: Precompiled Transfer
   description: This is a precompiled transfer benchmark of FISCO BCOS for caliper
@@ -20,43 +5,46 @@ test:
     type: local
     number: 4
   rounds:
-  - label: addUser
-    description: generate users for transfer test later
-    txNumber:
-    - 1000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    callback: benchmarks/samples/fisco-bcos/generate_txs_in_advance/addUser.js
-  - label: generate
-    description: transfer money between users
-    txNumber:
-    - 10000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 10000
-    callback: benchmarks/samples/fisco-bcos/generate_txs_in_advance/generate.js
-  - label: send
-    description: transfer money between users
-    txNumber:
-    - 10000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 10000
-    callback: benchmarks/samples/fisco-bcos/generate_txs_in_advance/send.js
+    - label: addUser
+      description: generate users for transfer test later
+      txNumber:
+        - 1000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/generate_txs_in_advance/addUser.js
+    - label: generate
+      description: transfer money between users
+      txNumber:
+        - 10000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 10000
+      workload:
+        module: benchmarks/samples/fisco-bcos/generate_txs_in_advance/generate.js
+    - label: send
+      description: transfer money between users
+      txNumber:
+        - 10000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 10000
+      workload:
+        module: benchmarks/samples/fisco-bcos/generate_txs_in_advance/send.js
 monitor:
   type:
-  - docker
-  - process
+    - docker
+    - process
   docker:
     name:
-    - node0
-    - node1
-    - node2
-    - node3
+      - node0
+      - node1
+      - node2
+      - node3
   process:
     - command: node
       arguments: fiscoBcosClientWorker.js

--- a/benchmarks/samples/fisco-bcos/helloworld/config.yaml
+++ b/benchmarks/samples/fisco-bcos/helloworld/config.yaml
@@ -1,18 +1,3 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   name: Hello World
   description: This is a helloworld benchmark of FISCO BCOS for caliper
@@ -20,34 +5,36 @@ test:
     type: local
     number: 1
   rounds:
-  - label: get
-    description: Test performance of getting name
-    txNumber:
-    - 10000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    callback: benchmarks/samples/fisco-bcos/helloworld/get.js
-  - label: set
-    description: Test performance of setting name
-    txNumber:
-    - 10000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    callback: benchmarks/samples/fisco-bcos/helloworld/set.js
+    - label: get
+      description: Test performance of getting name
+      txNumber:
+        - 10000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/helloworld/get.js
+    - label: set
+      description: Test performance of setting name
+      txNumber:
+        - 10000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/helloworld/set.js
 monitor:
   type:
-  - docker
-  - process
+    - docker
+    - process
   docker:
     name:
-    - node0
-    - node1
-    - node2
-    - node3
+      - node0
+      - node1
+      - node2
+      - node3
   process:
     - command: node
       arguments: fiscoBcosClientWorker.js

--- a/benchmarks/samples/fisco-bcos/transfer/precompiled/config.yaml
+++ b/benchmarks/samples/fisco-bcos/transfer/precompiled/config.yaml
@@ -1,18 +1,3 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   name: Precompiled Transfer
   description: This is a precompiled transfer benchmark of FISCO BCOS for caliper
@@ -20,36 +5,38 @@ test:
     type: local
     number: 4
   rounds:
-  - label: addUser
-    description: generate users for transfer test later
-    txNumber:
-    - 1000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    callback: benchmarks/samples/fisco-bcos/transfer/precompiled/addUser.js
-  - label: transfer
-    description: transfer money between users
-    txNumber:
-    - 10000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    arguments:
-      txnPerBatch: 10
-    callback: benchmarks/samples/fisco-bcos/transfer/precompiled/transfer.js
+    - label: addUser
+      description: generate users for transfer test later
+      txNumber:
+        - 1000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/transfer/precompiled/addUser.js
+    - label: transfer
+      description: transfer money between users
+      txNumber:
+        - 10000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/transfer/precompiled/transfer.js
+        arguments:
+          txnPerBatch: 10
 monitor:
   type:
-  - docker
-  - process
+    - docker
+    - process
   docker:
     name:
-    - node0
-    - node1
-    - node2
-    - node3
+      - node0
+      - node1
+      - node2
+      - node3
   process:
     - command: node
       arguments: fiscoBcosClientWorker.js

--- a/benchmarks/samples/fisco-bcos/transfer/solidity/config.yaml
+++ b/benchmarks/samples/fisco-bcos/transfer/solidity/config.yaml
@@ -1,18 +1,3 @@
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
----
 test:
   name: Solidity Transfer
   description: This is a solidity transfer benchmark of FISCO BCOS for caliper
@@ -20,36 +5,38 @@ test:
     type: local
     number: 4
   rounds:
-  - label: addUser
-    description: generate users for transfer test later
-    txNumber:
-    - 1000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    callback: benchmarks/samples/fisco-bcos/transfer/solidity/addUser.js
-  - label: transfer
-    description: transfer money between users
-    txNumber:
-    - 10000
-    rateControl:
-    - type: fixed-rate
-      opts:
-        tps: 1000
-    arguments:
-      txnPerBatch: 10
-    callback: benchmarks/samples/fisco-bcos/transfer/solidity/transfer.js
+    - label: addUser
+      description: generate users for transfer test later
+      txNumber:
+        - 1000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/transfer/solidity/addUser.js
+    - label: transfer
+      description: transfer money between users
+      txNumber:
+        - 10000
+      rateControl:
+        - type: fixed-rate
+          opts:
+            tps: 1000
+      workload:
+        module: benchmarks/samples/fisco-bcos/transfer/solidity/transfer.js
+        arguments:
+          txnPerBatch: 10
 monitor:
   type:
-  - docker
-  - process
+    - docker
+    - process
   docker:
     name:
-    - node0
-    - node1
-    - node2
-    - node3
+      - node0
+      - node1
+      - node2
+      - node3
   process:
     - command: node
       arguments: fiscoBcosClientWorker.js

--- a/benchmarks/scenario/simple/config-composite-rate.yaml
+++ b/benchmarks/scenario/simple/config-composite-rate.yaml
@@ -1,42 +1,43 @@
----
 test:
   name: simple
-  description: This is an example benchmark for caliper, to test the backend DLT's
+  description: >-
+    This is an example benchmark for caliper, to test the backend DLT's
     performance with simple account opening & querying transactions
   workers:
     type: local
     number: 5
   rounds:
-  - label: open
-    txDuration: 30
-    rateControl:
-      type: composite-rate
-      opts:
-        weights:
-        - 10
-        - 5
-        - 5
-        - 10
-        rateControllers:
-        - type: fixed-rate
-          opts:
-            tps: 20
-        - type: fixed-rate
-          opts:
-            tps: 40
-        - type: zero-rate
-          opts: {}
-        - type: fixed-rate
-          opts:
-            tps: 30
-        logChange: true
-    arguments:
-      money: 10000
-    callback: benchmarks/scenario/simple/open.js
+    - label: open
+      txDuration: 30
+      rateControl:
+        type: composite-rate
+        opts:
+          weights:
+            - 10
+            - 5
+            - 5
+            - 10
+          rateControllers:
+            - type: fixed-rate
+              opts:
+                tps: 20
+            - type: fixed-rate
+              opts:
+                tps: 40
+            - type: zero-rate
+              opts: {}
+            - type: fixed-rate
+              opts:
+                tps: 30
+          logChange: true
+      workload:
+        module: benchmarks/scenario/simple/open.js
+        arguments:
+          money: 10000
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/scenario/simple/config-feedback-rate.yaml
+++ b/benchmarks/scenario/simple/config-feedback-rate.yaml
@@ -1,4 +1,3 @@
----
 blockchain:
   type: fabric
   config: benchmarks/scenario/simple/fabric.json
@@ -7,21 +6,22 @@ test:
     type: local
     number: 5
   rounds:
-  - label: open
-    txNumber: 5000
-    rateControl:
-      type: fixed-feedback-rate
-      opts:
-        tps: 100
-        sleep_time: 1000
-        unfinished_per_client: 10
-    arguments:
-      money: 10000
-    callback: benchmarks/scenario/simple/open.js
+    - label: open
+      txNumber: 5000
+      rateControl:
+        type: fixed-feedback-rate
+        opts:
+          tps: 100
+          sleep_time: 1000
+          unfinished_per_client: 10
+      workload:
+        module: benchmarks/scenario/simple/open.js
+        arguments:
+          money: 10000
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/scenario/simple/config-linear-rate.yaml
+++ b/benchmarks/scenario/simple/config-linear-rate.yaml
@@ -1,26 +1,27 @@
----
 test:
   name: simple
-  description: This is an example benchmark for caliper, to test the backend DLT's
+  description: >-
+    This is an example benchmark for caliper, to test the backend DLT's
     performance with simple account opening & querying transactions
   workers:
     type: local
     number: 5
   rounds:
-  - label: open
-    txDuration: 15
-    rateControl:
-      type: linear-rate
-      opts:
-        startingTps: 25
-        finishingTps: 75
-    arguments:
-      money: 10000
-    callback: benchmarks/scenario/simple/open.js
+    - label: open
+      txDuration: 15
+      rateControl:
+        type: linear-rate
+        opts:
+          startingTps: 25
+          finishingTps: 75
+      workload:
+        module: benchmarks/scenario/simple/open.js
+        arguments:
+          money: 10000
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/scenario/simple/config-sawtooth.yaml
+++ b/benchmarks/scenario/simple/config-sawtooth.yaml
@@ -1,35 +1,38 @@
----
-# NOTE: the transfer function logic is not compatible with the corresponding Sawtooth batch builder
 test:
   name: simple
-  description: This is an example benchmark for caliper, to test the backend DLT's
+  description: >-
+    This is an example benchmark for caliper, to test the backend DLT's
     performance with simple account opening & querying transactions
   workers:
     type: local
     number: 1
   rounds:
-  - label: open
-    description: Test description for the opening of an account through the deployed chaincode
-    txNumber: 100
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 50
-    arguments:
-      money: 10000
-    callback: benchmarks/scenario/simple/open.js
-  - label: query
-    description: Test description for the query performance of the deployed chaincode
-    txNumber: 100
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 100
-    callback: benchmarks/scenario/simple/query.js
+    - label: open
+      description: >-
+        Test description for the opening of an account through the deployed
+        chaincode
+      txNumber: 100
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 50
+      workload:
+        module: benchmarks/scenario/simple/open.js
+        arguments:
+          money: 10000
+    - label: query
+      description: Test description for the query performance of the deployed chaincode
+      txNumber: 100
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/scenario/simple/query.js
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/scenario/simple/config.yaml
+++ b/benchmarks/scenario/simple/config.yaml
@@ -1,44 +1,49 @@
----
 test:
   name: simple
-  description: This is an example benchmark for caliper, to test the backend DLT's
+  description: >-
+    This is an example benchmark for caliper, to test the backend DLT's
     performance with simple account opening & querying transactions
   workers:
     type: local
     number: 1
   rounds:
-  - label: open
-    description: Test description for the opening of an account through the deployed chaincode
-    txNumber: 100
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 50
-    arguments:
-      money: 10000
-    callback: benchmarks/scenario/simple/open.js
-  - label: query
-    description: Test description for the query performance of the deployed chaincode
-    txNumber: 100
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 100
-    callback: benchmarks/scenario/simple/query.js
-  - label: transfer
-    description: Test description for transfering money between accounts
-    txNumber: 100
-    rateControl:
-          type: fixed-rate
-          opts:
-              tps: 50
-    arguments:
-        money: 100
-    callback: benchmarks/scenario/simple/transfer.js
+    - label: open
+      description: >-
+        Test description for the opening of an account through the deployed
+        chaincode
+      txNumber: 100
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 50
+      workload:
+        module: benchmarks/scenario/simple/open.js
+        arguments:
+          money: 10000
+    - label: query
+      description: Test description for the query performance of the deployed chaincode
+      txNumber: 100
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/scenario/simple/query.js
+    - label: transfer
+      description: Test description for transfering money between accounts
+      txNumber: 100
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 50
+      workload:
+        module: benchmarks/scenario/simple/transfer.js
+        arguments:
+          money: 100
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/scenario/simple/config_long.yaml
+++ b/benchmarks/scenario/simple/config_long.yaml
@@ -1,25 +1,26 @@
----
 test:
   name: simple
-  description: This is an example benchmark for caliper, to test the backend DLT's
+  description: >-
+    This is an example benchmark for caliper, to test the backend DLT's
     performance with simple account opening & querying transactions
   workers:
     type: local
     number: 5
   rounds:
-  - label: open
-    txDuration: 3600
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 100
-    arguments:
-      money: 10000
-    callback: benchmarks/scenario/simple/open.js
+    - label: open
+      txDuration: 3600
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 100
+      workload:
+        module: benchmarks/scenario/simple/open.js
+        arguments:
+          money: 10000
 monitor:
   type:
-  - docker
+    - docker
   docker:
     name:
-    - all
+      - all
   interval: 1

--- a/benchmarks/scenario/smallbank/config.yaml
+++ b/benchmarks/scenario/smallbank/config.yaml
@@ -1,4 +1,3 @@
----
 test:
   name: smallbank
   description: This is smallbank benchmark for caliper
@@ -6,26 +5,28 @@ test:
     type: local
     number: 5
   rounds:
-  - label: smallOperations
-    txNumber: 500
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 20
-    arguments:
-      accounts: 400
-      txnPerBatch: 1
-    callback: benchmarks/scenario/smallbank/smallbankOperations.js
-  - label: query
-    txNumber: 500
-    rateControl:
-      type: fixed-rate
-      opts:
-        tps: 50
-    callback: benchmarks/scenario/smallbank/query.js
+    - label: smallOperations
+      txNumber: 500
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 20
+      workload:
+        module: benchmarks/scenario/smallbank/smallbankOperations.js
+        arguments:
+          accounts: 400
+          txnPerBatch: 1
+    - label: query
+      txNumber: 500
+      rateControl:
+        type: fixed-rate
+        opts:
+          tps: 50
+      workload:
+        module: benchmarks/scenario/smallbank/query.js
 monitor:
   type: docker
   docker:
     name:
-    - all
+      - all
   interval: 1


### PR DESCRIPTION
The PR contains the following (scripted) updates to the benchmarkconfig YAMLs:
* `test.rounds[i].callback` -> `test.rounds[i].workload.module`
* `test.rounds[i].arguments` -> `test.rounds[i].workload.arguments`, if present

Signed-off-by: Attila Klenik <a.klenik@gmail.com>