### PR TITLE
Change layout to permit different contract type reports

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ nav:
     - Overview: index.md
     - Fabric:
       - Performance: fabric/performance.md
-      - Results:
+      - Node Contract:
         - v2.1.0:
           - Configuration: fabric/performance/2.1.0/nodeJS/nodeSDK/configuration.md
           - Evaluate:


### PR DESCRIPTION
Minor modification to mkdocs yaml layout, meaning we can stack contract types on the menu to give results under them

Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>