### PR TITLE
Update benchmark descriptions

### DIFF
--- a/benchmarks/api/fabric/couchDB/contract/create-private-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/create-private-asset.yaml
@@ -5,7 +5,8 @@ test:
     with a CouchDB world state database using the `fixed-asset` NodeJS chaincode
     contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
     round invokes the `createPrivateAsset` method, with successive rounds
-    increasing the bytesize of the asset added into the Private data store.
+    increasing the bytesize of the asset added into the Private Data 
+    Collection of the authorized organization.
   workers:
     type: local
     number: 5
@@ -14,8 +15,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 8000 bytes into the Private data store at a
-        fixed TPS rate.
+        inserts an asset of size 8000 bytes into the Private Data Collection
+        of the authorized organization at a fixed TPS rate.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -31,7 +32,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 100 bytes into the Private data store.
+        inserts an asset of size 100 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -48,7 +50,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 200 bytes into the Private data store.
+        inserts an asset of size 200 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -65,7 +68,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 500 bytes into the Private data store.
+        inserts an asset of size 500 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -82,7 +86,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 1000 bytes into the Private data store.
+        inserts an asset of size 1000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -99,7 +104,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 2000 bytes into the Private data store.
+        inserts an asset of size 2000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -116,7 +122,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 5000 bytes into the Private data store.
+        inserts an asset of size 5000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -133,7 +140,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 10000 bytes into the Private data store.
+        inserts an asset of size 10000 bytes into the Private Data Collection 
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:

--- a/benchmarks/api/fabric/couchDB/contract/get-private-asset.yaml
+++ b/benchmarks/api/fabric/couchDB/contract/get-private-asset.yaml
@@ -14,7 +14,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 100 bytes.
+        performs a getPrivateData on an item that matches an asset of size 100 bytes.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -40,7 +40,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 200 bytes.
+        performs a getPrivateData on an item that matches an asset of size 200 bytes.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -59,7 +59,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 500 bytes.
+        performs a getPrivateData on an item that matches an asset of size 500 bytes.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -78,7 +78,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 1000 bytes.
+        performs a getPrivateData on an item that matches an asset of size 1000 bytes.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -97,7 +97,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 2000 bytes.
+        performs a getPrivateData on an item that matches an asset of size 2000 bytes.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -116,7 +116,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 5000 bytes.
+        performs a getPrivateData on an item that matches an asset of size 5000 bytes.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -135,7 +135,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 10000
+        performs a getPrivateData on an item that matches an asset of size 10000
         bytes.
       chaincodeID: fixed-asset
       txDuration: 300
@@ -155,7 +155,7 @@ test:
       description: >-
         Test an evaluateTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `getPrivateAsset`. This method
-        performs a getState on an item that matches an asset of size 8000 bytes
+        performs a getPrivateData on an item that matches an asset of size 8000 bytes
         at a fixed TPS.
       chaincodeID: fixed-asset
       txDuration: 300

--- a/benchmarks/api/fabric/levelDB/contract/create-private-asset.yaml
+++ b/benchmarks/api/fabric/levelDB/contract/create-private-asset.yaml
@@ -5,7 +5,8 @@ test:
     with a LevelDB world state database using the `fixed-asset` NodeJS chaincode
     contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
     round invokes the `createPrivateAsset` method, with successive rounds
-    increasing the bytesize of the private asset added into the Private Store
+    increasing the bytesize of the private asset added into the Private Data
+    Collection of the authorized organization.
   workers:
     type: local
     number: 10
@@ -14,8 +15,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 8000 bytes into the Private Store at a fixed
-        TPS rate.
+        inserts an asset of size 8000 bytes into the Private Data Collection
+        of the authorized organization at a fixed TPS rate.
       chaincodeID: fixed-asset
       txDuration: 30
       rateControl:
@@ -31,7 +32,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 100 bytes into the Private Store.
+        inserts an asset of size 100 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -47,7 +49,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 200 bytes into the Private Store.
+        inserts an asset of size 200 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -63,7 +66,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 500 bytes into the Private Store.
+        inserts an asset of size 500 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -79,7 +83,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 1000 bytes into the Private Store.
+        inserts an asset of size 1000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -95,7 +100,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 2000 bytes into the Private Store.
+        inserts an asset of size 2000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -111,7 +117,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 5000 bytes into the Private Store.
+        inserts an asset of size 5000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:
@@ -127,7 +134,8 @@ test:
       description: >-
         Test a submitTransaction() Gateway method against the NodeJS
         `fixed-asset` Smart Contract method named `createPrivateAsset`, which
-        inserts an asset of size 10000 bytes into the Private Store.
+        inserts an asset of size 10000 bytes into the Private Data Collection
+        of the authorized organization.
       chaincodeID: fixed-asset
       txDuration: 300
       rateControl:


### PR DESCRIPTION
Update the benchmark description for the create-private-asset.yaml and get-private-asset.yaml files to say `Private Data Collection` instead of `private data store`

Signed-off-by: lmuswere <lynn14m@gmail.com>