### PR TITLE
Fix helper.js and config.yaml for fabcar

### DIFF
--- a/benchmarks/samples/fabric/fabcar/config.yaml
+++ b/benchmarks/samples/fabric/fabcar/config.yaml
@@ -4,10 +4,9 @@ test:
     number: 5
   rounds:
     - label: Change car owner.
-      txDuration:
-        - 30
+      txDuration: 30
       rateControl:
-        - type: fixed-load
+          type: fixed-load
           opts:
             transactionLoad: 5
       workload:
@@ -15,10 +14,9 @@ test:
         arguments:
           assets: 1000
     - label: Query all cars.
-      txDuration:
-        - 30
+      txDuration: 30
       rateControl:
-        - type: fixed-load
+          type: fixed-load
           opts:
             transactionLoad: 5
       workload:
@@ -28,10 +26,9 @@ test:
           startKey: '1'
           endKey: '50'
     - label: Query a car.
-      txDuration:
-        - 30
+      txDuration: 30
       rateControl:
-        - type: fixed-load
+          type: fixed-load
           opts:
             transactionLoad: 5
       workload:
@@ -39,10 +36,9 @@ test:
         arguments:
           assets: 1000
     - label: Create a car.
-      txDuration:
-        - 30
+      txDuration: 30
       rateControl:
-        - type: fixed-load
+          type: fixed-load
           opts:
             transactionLoad: 5
       workload:

--- a/benchmarks/samples/fabric/fabcar/helper.js
+++ b/benchmarks/samples/fabric/fabcar/helper.js
@@ -20,6 +20,10 @@ let models = ['Prius', 'Mustang', 'Tucson', 'Passat', 'S', '205', 'S22L', 'Punto
 let owners = ['Tomoko', 'Brad', 'Jin Soo', 'Max', 'Adrianna', 'Michel', 'Aarav', 'Pari', 'Valeria', 'Shotaro'];
 
 let carNumber;
+let color;
+let make;
+let model;
+let owner;
 let txIndex = 0;
 
 module.exports.createCar = async function (bc, workerIndex, args) {


### PR DESCRIPTION
fabcar in sample cannot work due to config.yaml format error and
helper.js errors. This PR corrects config.yaml format and adds
variable declaration.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>