### PR TITLE
Fix cannot remove mychannel.tx

### DIFF
--- a/networks/fabric/config_kafka/generate.sh
+++ b/networks/fabric/config_kafka/generate.sh
@@ -10,7 +10,7 @@ fi
 
 rm -rf ./crypto-config/
 rm -f ./genesis.block
-rm -f ./mychannel.tx
+rm -rf ./mychannel.tx
 
 ./bin/cryptogen generate --config=./crypto-config.yaml
 ./bin/configtxgen -profile OrdererGenesis -outputBlock genesis.block -channelID syschannel

--- a/networks/fabric/config_raft/generate.sh
+++ b/networks/fabric/config_raft/generate.sh
@@ -10,7 +10,7 @@ fi
 
 rm -rf ./crypto-config/
 rm -f ./genesis.block
-rm -f ./mychannel.tx
+rm -rf ./mychannel.tx
 
 ./bin/cryptogen generate --config=./crypto-config.yaml
 ./bin/configtxgen -profile OrdererGenesis -outputBlock genesis.block -channelID syschannel

--- a/networks/fabric/config_solo/generate.sh
+++ b/networks/fabric/config_solo/generate.sh
@@ -10,7 +10,7 @@ fi
 
 rm -rf ./crypto-config/
 rm -f ./orgs.genesis.block
-rm -f ./mychannel.tx
+rm -rf ./mychannel.tx
 
 # The below assumes you have the relevant code available to generate the cryto-material
 ./bin/cryptogen generate --config=./crypto-config.yaml

--- a/networks/fabric/config_solo_raft/generate.sh
+++ b/networks/fabric/config_solo_raft/generate.sh
@@ -10,7 +10,7 @@ fi
 
 rm -rf ./crypto-config/
 rm -f ./genesis.block
-rm -f ./mychannel.tx
+rm -rf ./mychannel.tx
 
 ./bin/cryptogen generate --config=./crypto-config.yaml
 ./bin/configtxgen -profile OrdererGenesis -outputBlock genesis.block -channelID syschannel


### PR DESCRIPTION
If you run the following command (forgot to run `generate.sh` first):

```bash
npm init -y
npm install --only=prod @hyperledger/caliper-cli@0.4.0
npx caliper bind --caliper-bind-sut fabric:1.4
npx caliper launch manager --caliper-workspace . --caliper-benchconfig benchmarks/scenario/simple/config.yaml --caliper-networkconfig networks/fabric/v1/v1.4.1/2org1peergoleveldb/fabric-go.yaml
```

You will get an **empty folder** `mychannel.tx` in `networks/fabric/config_solo/`.

After this happens, run `generate.sh` and you will get the following error:

```bash
rm: cannot remove './mychannel.tx': Is a directory
[common.tools.configtxgen] main -> FATA 011 Error on outputChannelCreateTx: Error writing channel create tx: open mychannel.tx: is a directory
```

This problem can be fixed by replacing `rm -f` in `generate.sh` with `rm -rf`.