### PR TITLE
Fix flags for the latest stable ethereum

### DIFF
--- a/networks/ethereum/1node-clique/docker-compose.yml
+++ b/networks/ethereum/1node-clique/docker-compose.yml
@@ -24,4 +24,4 @@ services:
       - ./keys:/root/.ethereum/keystore
     ports:
       - 8546:8546
-    command: --unlock 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --password /root/.ethereum/keystore/password --mine --minerthreads 2 --etherbase 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --ws --wsaddr 0.0.0.0 --wsorigins='*' --wsapi admin,eth,miner,personal,web3 --allow-insecure-unlock --nodiscover --gasprice 1
+    command: --unlock 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --password /root/.ethereum/keystore/password --mine --miner.threads 2 --miner.etherbase 0xc0A8e4D217eB85b812aeb1226fAb6F588943C2C2 --ws --ws.addr 0.0.0.0 --ws.origins='*' --ws.api admin,eth,miner,personal,web3 --allow-insecure-unlock --nodiscover --miner.gasprice 1


### PR DESCRIPTION
From go-ethereum 1.10, command flags have been changed.
Therefore sample in networks/ethereum/1node-clique can't work.
This PR fixes the issue.

Signed-off-by: Nao Nishijima <nao.nishijima.xt@hitachi.com>