### PR TITLE
fix java chaincode support

### DIFF
--- a/.github/scripts/run-fabric-tests.sh
+++ b/.github/scripts/run-fabric-tests.sh
@@ -56,12 +56,8 @@ cd ..
 #
 # fabcar
 #
-# go and javascript currently work, java doesn't
-# TODO: update once java works
-if [ "$CC_SRC_LANGUAGE" != "java" ]; then
-  echo "---- Deploying fabcar $CC_SRC_PATH chaincode"
-  ./network.sh deployCC -ccn fabcar -ccp ../../caliper-benchmarks/src/fabric/samples/fabcar/$CC_SRC_PATH -ccl $CC_SRC_LANGUAGE
-fi
+echo "---- Deploying fabcar $CC_SRC_PATH chaincode"
+./network.sh deployCC -ccn fabcar -ccp ../../caliper-benchmarks/src/fabric/samples/fabcar/$CC_SRC_PATH -ccl $CC_SRC_LANGUAGE
 
 #
 # marbles
@@ -106,12 +102,8 @@ fi
 #
 # fixed-asset
 #
-# only javascript works, go and java don't.
-# TODO: Update once go and java work
-if [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
-  echo "---- Deploying fixed-asset $CC_SRC_PATH chaincode"
-  ./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset/$CC_SRC_PATH -ccl $CC_SRC_LANGUAGE
-fi
+echo "---- Deploying fixed-asset $CC_SRC_PATH chaincode"
+./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset/$CC_SRC_PATH -ccl $CC_SRC_LANGUAGE
 
 #
 # fixed-asset-base
@@ -132,12 +124,8 @@ popd
 
 # benchmark chaincodes whose ccn is: fabcar, marbles, simple, fixed-asset
 
-# go and javascript currently work, java doesn't
-# TODO: update once java works
-if [ "$CC_SRC_LANGUAGE" != "java" ]; then
-  echo "---- Running fabcar benchmarks"
-  npx caliper launch manager --caliper-workspace ./ --caliper-networkconfig networks/fabric/test-network.yaml --caliper-benchconfig benchmarks/samples/fabric/fabcar/config.yaml --caliper-flow-only-test --caliper-fabric-gateway-enabled
-fi
+echo "---- Running fabcar benchmarks"
+npx caliper launch manager --caliper-workspace ./ --caliper-networkconfig networks/fabric/test-network.yaml --caliper-benchconfig benchmarks/samples/fabric/fabcar/config.yaml --caliper-flow-only-test --caliper-fabric-gateway-enabled
 
 # only javascript works, go doesn't and java not available.
 # TODO: Update once go works
@@ -159,11 +147,7 @@ fi
 #   npx caliper launch manager --caliper-workspace ./ --caliper-networkconfig networks/fabric/test-network.yaml --caliper-benchconfig benchmarks/scenario/smallbank/config.yaml --caliper-flow-only-test --caliper-fabric-gateway-enabled
 # fi
 
-# only javascript works, go and java don't.
-# TODO: Update once go and java work
-if [ "$CC_SRC_LANGUAGE" = "javascript" ]; then
-  echo "---- Running fixed-asset benchmarks"
-  npx caliper launch manager --caliper-workspace ./ --caliper-networkconfig networks/fabric/test-network.yaml --caliper-benchconfig benchmarks/api/fabric/test.yaml --caliper-flow-only-test --caliper-fabric-gateway-enabled
-fi
+echo "---- Running fixed-asset benchmarks"
+npx caliper launch manager --caliper-workspace ./ --caliper-networkconfig networks/fabric/test-network.yaml --caliper-benchconfig benchmarks/api/fabric/test.yaml --caliper-flow-only-test --caliper-fabric-gateway-enabled
 
 echo "---- Test for $CC_SRC_PATH chaincodes and benchmarks completed successfully"

--- a/.github/workflows/fabric-tests.yaml
+++ b/.github/workflows/fabric-tests.yaml
@@ -10,10 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cc-env: [go, java, node]
+        cc-env: [go,java,node]
     steps:
     - uses: actions/checkout@v2
+# TODO: add explicit go version rather than rely on implicit go version
     - uses: actions/setup-node@v2
       with:
         node-version: 14
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '8'
+      if: ${{ matrix.cc-env == 'java' }}
     - run: .github/scripts/run-fabric-tests.sh ${{ matrix.cc-env }}

--- a/networks/fabric/README.md
+++ b/networks/fabric/README.md
@@ -62,20 +62,19 @@ Fabcar has chaincode for Go, Java, Javascript. It doesn't make use of rich queri
 
 Ensure you are in the `fabric-samples/test-network` directory
 
-To deploy the Go version
+##### To deploy the Go version
 
 ```bash
 ./network.sh deployCC -ccn fabcar -ccp ../../caliper-benchmarks/src/fabric/samples/fabcar/go -ccl go
 ```
 
-**THE JAVA VERSION CURRENTLY DOES NOT DEPLOY**
-To deploy the Java version
+##### To deploy the Java version
 
 ```bash
 ./network.sh deployCC -ccn fabcar -ccp ../../caliper-benchmarks/src/fabric/samples/fabcar/java -ccl java
 ```
 
-To deploy the Javascript version
+##### To deploy the Javascript version
 
 ```bash
 ./network.sh deployCC -ccn fabcar -ccp ../../caliper-benchmarks/src/fabric/samples/fabcar/node -ccl javascript
@@ -98,25 +97,25 @@ Marbles comes in both rich query and no rich query flavours and has has chaincod
 Ensure you are in the `fabric-samples/test-network` directory
 
 **THE GO VERSIONS CURRENTLY DOES NOT DEPLOY**
-To deploy the Go with rich queries version
+##### To deploy the Go with rich queries version
 
 ```bash
 ./network.sh deployCC -ccn marbles -ccp ../../caliper-benchmarks/src/fabric/samples/marbles/go -ccl go
 ```
 
-To deploy the Go without rich queries version
+##### To deploy the Go without rich queries version
 
 ```bash
 ./network.sh deployCC -ccn marbles -ccp ../../caliper-benchmarks/src/fabric/samples/marbles-norichquery/go -ccl go
 ```
 
-To deploy the Javascript with rich queries version
+##### To deploy the Javascript with rich queries version
 
 ```bash
 ./network.sh deployCC -ccn marbles -ccp ../../caliper-benchmarks/src/fabric/samples/marbles/node -ccl javascript
 ```
 
-To deploy the Javascript without rich queries version
+##### To deploy the Javascript without rich queries version
 
 ```bash
 ./network.sh deployCC -ccn marbles -ccp ../../caliper-benchmarks/src/fabric/samples/marbles-norichquery/node -ccl javascript
@@ -138,14 +137,16 @@ Simple has chaincode for Go, Javascript. It doesn't make use of rich queries so 
 
 Ensure you are in the `fabric-samples/test-network` directory
 
-To deploy the Go version
 **THE GO VERSION CURRENTLY DOES NOT DEPLOY**
+##### To deploy the Go version
+
+
 
 ```bash
 ./network.sh deployCC -ccn simple -ccp ../../caliper-benchmarks/src/fabric/scenario/simple/go -ccl go
 ```
 
-To deploy the Javascript version
+##### To deploy the Javascript version
 
 ```bash
 ./network.sh deployCC -ccn simple -ccp ../../caliper-benchmarks/src/fabric/scenario/simple/node -ccl javascript
@@ -167,8 +168,9 @@ Smallbank has chaincode for Go only. It doesn't make use of rich queries so can 
 
 Ensure you are in the `fabric-samples/test-network` directory
 
-To deploy the Go version
 **THE GO VERSION CURRENTLY DOES NOT DEPLOY**
+##### To deploy the Go version
+
 
 ```bash
 ./network.sh deployCC -ccn smallbank -ccp ../../caliper-benchmarks/src/fabric/scenario/smallbank/go -ccl go
@@ -200,21 +202,19 @@ There are several benchmarks available within the `benchmarks/api/fabric/contrac
 
 Ensure you are in the `fabric-samples/test-network` directory
 
-To deploy the Go version
-**THE GO VERSION CURRENTLY DOES NOT DEPLOY**
+##### To deploy the Go version
 
 ```bash
 ./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset/go -ccl go
 ```
 
-**THE JAVA VERSION CURRENTLY DOES NOT DEPLOY**
-To deploy the Java version
+##### To deploy the Java version
 
 ```bash
 ./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset/java -ccl java
 ```
 
-To deploy the Javascript version
+##### To deploy the Javascript version
 
 ```bash
 ./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset/node -ccl javascript
@@ -235,13 +235,13 @@ fixed-asset-base is equivalent to fixed-asset but instead it doesn't make use of
 
 Ensure you are in the `fabric-samples/test-network` directory. Note here that we deploy with a chaincode ID of `fixed-asset` not `fixed-asset-base`.
 
-To deploy the Go version
+##### To deploy the Go version
 
 ```bash
 ./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset-base/go -ccl go
 ```
 
-To deploy the Javascript version
+##### To deploy the Javascript version
 
 ```bash
 ./network.sh deployCC -ccn fixed-asset -ccp ../../caliper-benchmarks/src/fabric/api/fixed-asset-base/node -ccl javascript

--- a/src/fabric/api/fixed-asset/java/build.gradle
+++ b/src/fabric/api/fixed-asset/java/build.gradle
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.3'
-    id 'java'
+    id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id 'application'
 }
 
 version '0.0.1'
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.1.0'
+    compile group: 'org.hyperledger.fabric-chaincode-java', name: 'fabric-chaincode-shim', version: '2.2.3'
     compile group: 'org.json', name: 'json', version: '20180813'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
@@ -51,3 +51,5 @@ test {
 tasks.withType(JavaCompile) {
   options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation" << "-parameters"
 }
+
+installDist.dependsOn test

--- a/src/fabric/api/fixed-asset/java/gradle/wrapper/gradle-wrapper.properties
+++ b/src/fabric/api/fixed-asset/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/fabric/samples/fabcar/java/build.gradle
+++ b/src/fabric/samples/fabcar/java/build.gradle
@@ -1,8 +1,4 @@
 /*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
 * http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
@@ -14,9 +10,8 @@
 
 
 plugins {
-    // id 'checkstyle'
-    id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'java-library'
+    id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id 'application'
     id 'jacoco'
 }
 
@@ -24,7 +19,7 @@ group 'org.hyperledger.fabric.samples'
 version '1.0-SNAPSHOT'
 
 dependencies {
-    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:1.4.2'
+    implementation 'org.hyperledger.fabric-chaincode-java:fabric-chaincode-shim:2.2.3'
     implementation 'com.owlike:genson:1.5'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation 'org.assertj:assertj-core:3.11.1'
@@ -36,23 +31,10 @@ repositories {
         url "https://nexus.hyperledger.org/content/repositories/snapshots/"
     }
     jcenter()
-    maven { 
-        url 'https://jitpack.io' 
+    maven {
+        url 'https://jitpack.io'
     }
 }
-
-// checkstyle {
-//     toolVersion '8.21'
-//     configFile file("config/checkstyle/checkstyle.xml")
-// }
-
-// checkstyleMain {
-//     source ='src/main/java'
-// }
-
-// checkstyleTest {
-//     source ='src/test/java'
-// }
 
 shadowJar {
     baseName = 'chaincode'
@@ -64,13 +46,6 @@ shadowJar {
 }
 
 jacocoTestCoverageVerification {
-    afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
-            fileTree(dir: it, exclude:  [
-                    'org/hyperledger/fabric/samples/fabcar/Start.*'
-            ])
-        })
-    }
     violationRules {
         rule {
             limit {
@@ -78,7 +53,7 @@ jacocoTestCoverageVerification {
             }
         }
     }
-    
+
     finalizedBy jacocoTestReport
 }
 
@@ -90,3 +65,4 @@ test {
 }
 
 check.dependsOn jacocoTestCoverageVerification
+installDist.dependsOn check

--- a/src/fabric/samples/fabcar/java/gradle/wrapper/gradle-wrapper.properties
+++ b/src/fabric/samples/fabcar/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/fabric/samples/fabcar/java/settings.gradle
+++ b/src/fabric/samples/fabcar/java/settings.gradle
@@ -12,4 +12,4 @@
 * limitations under the License.
 */
 
-rootProject.name = 'java-chaincode-bootstrap'
+rootProject.name = 'fabcar'


### PR DESCRIPTION
This gets java deploying and for the most part working, however there are problems in the way the java contract-api chaincode is implemented for fxed-asset which results in the benchmarks recording all failures for some of the benchmarks run, this will be addressed in #181 

Also note that go chaincode for fixed-asset has been addressed in another issue and so this enables running the chaincode and benchmark in the build

Signed-off-by: D <d_kelsey@uk.ibm.com>