### PR TITLE
Add support for private asset benchmarks to the go fixed-asset chaincode

### DIFF
--- a/benchmarks/api/fabric/lib/helper.js
+++ b/benchmarks/api/fabric/lib/helper.js
@@ -136,7 +136,7 @@ module.exports.addMixedBatchAssets = async function(bcObj, context, clientIdx, a
 
     // -Generate all assets
     const assets = [];
-    let idx =0;
+    let idx = 0;
     for (let i=0; i<testAssetNum; i++) {
         // loop over baseAssets defined above
         const asset = {};

--- a/src/fabric/api/fixed-asset/go/assets/FixedAsset.go
+++ b/src/fabric/api/fixed-asset/go/assets/FixedAsset.go
@@ -8,3 +8,7 @@ type FixedAsset struct {
 	Bytesize int    `json:"byteSize"`
 	Content  string `json:"content"`
 }
+
+type PrivateAssetContent struct {
+	Content FixedAsset `json:"content"`
+}


### PR DESCRIPTION
This adds missing methods so that the

- create-private-asset.yaml
- get-private-asset.yaml

Can now be used against the golang contract-api based fixed-asset
chaincode

Signed-off-by: D <d_kelsey@uk.ibm.com>