### PR TITLE
Add support for a composite read/write transaction to fixed asset

### DIFF
--- a/benchmarks/api/fabric/composite-transaction.yaml
+++ b/benchmarks/api/fabric/composite-transaction.yaml
@@ -1,0 +1,116 @@
+test:
+  name: composite-transaction
+  description: >-
+    This is a duration based benchmark targeting a Hyperledger Fabric network
+    using the `fixed-asset` NodeJS chaincode
+    contract that is interacted with via a Fabric-SDK-Node Gateway. Each test
+    round reads x number of existing keys snd writes y number to existing keys for a specific size. Successive  a-priori created assets of larger byte size.
+  workers:
+    type: local
+    number: 10
+  rounds:
+    - label: create-keys-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts 8000 keys in batches of 50 assets of size 100k bytes into the World State
+      chaincodeID: fixed-asset
+      txNumber: 1
+      rateControl:
+        type: fixed-load
+        opts:
+          transactionLoad: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/workloads/compositeTx/preload.js
+        arguments:
+          chaincodeID: fixed-asset
+          assets: 8000
+          byteSize: 100
+          batchSize: 50
+    - label: composite-tx-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `deleteAsset`. This method
+        performs a deleteState on an item that matches an asset of size 100
+        bytes.
+      chaincodeID: fixed-asset
+      txNumber: 2000
+      rateControl:
+        type: fixed-load
+        opts:
+          transactionLoad: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/workloads/compositeTx/read-write-asset.js
+        arguments:
+          chaincodeID: fixed-asset
+          assets: 8000
+          byteSize: 100
+          read: 2
+          write:
+            number: 2
+            previouslyRead: read
+    - label: delete-keys-100
+      description: >-
+        Test a submitTransaction() Gateway method against the NodeJS
+        `fixed-asset` Smart Contract method named `createAssetsFromBatch`, which
+        inserts 8000 keys in batches of 50 assets of size 100k bytes into the World State
+      chaincodeID: fixed-asset
+      txNumber: 1
+      rateControl:
+        type: fixed-load
+        opts:
+          transactionLoad: 20
+          startingTps: 10
+      workload:
+        module: benchmarks/api/fabric/workloads/compositeTx/clean.js
+        arguments:
+          chaincodeID: fixed-asset
+          assets: 8000
+          byteSize: 100
+          batchSize: 50
+monitors:
+    resource:
+    - module: prometheus
+      options:
+        url: "http://localhost:9090"
+        metrics:
+          include: [dev-.*, couch, peer, orderer]
+          queries:
+          - name: Avg Memory (MB)
+            query: 'sum(container_memory_rss{name=~".+"}) by (name)'
+            step: 10
+            label: name
+            statistic: avg
+            multiplier: 0.000001
+          - name:   CPU (%)
+            query: sum(rate(container_cpu_usage_seconds_total{name=~".+"}[1m])) by (name)
+            step: 10
+            label: name
+            statistic: avg
+            multiplier: 100
+          - name: Network In (MB)
+            query: sum(rate(container_network_receive_bytes_total{name=~".+"}[1m])) by (name)
+            step: 10
+            label: name
+            statistic: sum
+            multiplier: 0.000001
+          - name: Network Out (MB)
+            query: sum(rate(container_network_transmit_bytes_total{name=~".+"}[1m])) by (name)
+            step: 10
+            label: name
+            statistic: sum
+            multiplier: 0.000001
+          - name: Disc Write (MB)
+            query: sum(rate(container_fs_writes_bytes_total{name=~".+"}[1m])) by (name)
+            step: 10
+            label: name
+            statistic: sum
+            multiplier: 0.000001
+          - name: Disc Read (MB)
+            query: sum(rate(container_fs_reads_bytes_total{name=~".+"}[1m])) by (name)
+            step: 10
+            label: name
+            statistic: sum
+            multiplier: 0.000001

--- a/benchmarks/api/fabric/workloads/compositeTx/preload.js
+++ b/benchmarks/api/fabric/workloads/compositeTx/preload.js
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+
+const bytes = (s) => {
+    return ~-encodeURI(s).split(/%..|./).length;
+};
+
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+
+/**
+ * Workload module for the benchmark round.
+ */
+class Preload extends WorkloadModuleBase {
+    /**
+     * Initializes the workload module instance.
+     */
+    constructor() {
+        super();
+        this.txIndex = 0;
+        this.chaincodeID = '';
+        this.assetsPerWorker = [];
+        this.asset = {};
+        this.byteSize = 0;
+    }
+
+    /**
+     * Initialize the workload module with the given parameters.
+     * @param {number} workerIndex The 0-based index of the worker instantiating the workload module.
+     * @param {number} totalWorkers The total number of workers participating in the round.
+     * @param {number} roundIndex The 0-based index of the currently executing round.
+     * @param {Object} roundArguments The user-provided arguments for the round from the benchmark configuration file.
+     * @param {BlockchainInterface} sutAdapter The adapter of the underlying SUT.
+     * @param {Object} sutContext The custom context object provided by the SUT adapter.
+     * @async
+     */
+    async initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext) {
+        await super.initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext);
+
+        const args = this.roundArguments;
+        this.keys = args.assets ? parseInt(args.assets) : 0;
+        this.chaincodeID = args.chaincodeID ? args.chaincodeID : 'fixed-asset';
+        this.byteSize = args.byteSize ? args.byteSize : 100;
+        this.batchSize = args.batchSize ? parseInt(args.batchSize) : 1;
+        const assetNumber = args.assets ? parseInt(args.assets) : 2
+        this.assetsPerWorker = Math.floor(assetNumber / totalWorkers);
+        if (this.workerIndex == 0){
+            const reminder = assetNumber % totalWorkers;
+            this.assetsPerWorker += reminder;
+        }
+        this.batchesNum = Math.ceil(this.assetsPerWorker/this.batchSize);
+
+        this.asset = {
+            docType: this.chaincodeID,
+            content: '',
+            creator: 'client' + this.workerIndex,
+            byteSize: this.byteSize
+        };
+
+        const paddingSize = this.byteSize - bytes(JSON.stringify(this.asset));
+        this.asset.content = 'B'.repeat(paddingSize);
+    }
+
+    /**
+     * Assemble TXs for the round.
+     * @return {Promise<TxStatus[]>}
+     */
+    async submitTransaction() {
+        for(let i = 0; i < this.batchesNum; i++){
+            let batch = [];
+            for (let i = 0; (i < this.batchSize) && (this.txIndex < this.assetsPerWorker); i++) {
+                this.asset.uuid = 'client' + this.workerIndex + '_' + this.byteSize + '_' + this.txIndex;
+                const batchAsset = JSON.parse(JSON.stringify(this.asset));
+                batch.push(batchAsset);
+                this.txIndex++;
+            }
+
+            const args = {
+                contractId: this.chaincodeID,
+                contractFunction: 'createAssetsFromBatch',
+                contractArguments: [JSON.stringify(batch)],
+                readOnly: false
+            };
+
+            console.log('sending request,', args);
+            await this.sutAdapter.sendRequests(args);
+            console.log('sent request', args);
+        }
+    }
+}
+/**
+ * Create a new instance of the workload module.
+ * @return {WorkloadModuleInterface}
+ */
+function createWorkloadModule() {
+    return new Preload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;

--- a/benchmarks/api/fabric/workloads/compositeTx/read-write-asset.js
+++ b/benchmarks/api/fabric/workloads/compositeTx/read-write-asset.js
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict';
+const bytes = (s) => {
+    return ~-encodeURI(s).split(/%..|./).length;
+};
+
+const writeOptions = {
+    read: 'read',
+    notRead: 'notRead',
+    random: 'random',
+  };
+
+const helper = require('../helper');
+const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
+
+/**
+ * Workload module for the benchmark round.
+ */
+class CompositeTxWorkload extends WorkloadModuleBase {
+    /**
+     * Initializes the workload module instance.
+     */
+    constructor() {
+        super();
+        this.chaincodeID = '';
+        this.byteSize = 0;
+        this.readSize = 0;
+        this.writeSize = 0;
+        this.previouslyRead = writeOptions.random; //use enum to say the mode(include random)
+    }
+
+    /**
+     * Initialize the workload module with the given parameters.
+     * @param {number} workerIndex The 0-based index of the worker instantiating the workload module.
+     * @param {number} totalWorkers The total number of workers participating in the round.
+     * @param {number} roundIndex The 0-based index of the currently executing round.
+     * @param {Object} roundArguments The user-provided arguments for the round from the benchmark configuration file.
+     * @param {BlockchainInterface} sutAdapter The adapter of the underlying SUT.
+     * @param {Object} sutContext The custom context object provided by the SUT adapter.
+     * @async
+     */
+    async initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext) {
+        await super.initializeWorkloadModule(workerIndex, totalWorkers, roundIndex, roundArguments, sutAdapter, sutContext);
+
+        const args = this.roundArguments;
+        this.chaincodeID = args.chaincodeID ? args.chaincodeID : 'fixed-asset';
+        const assetNumber = args.assets ? parseInt(args.assets) : 2
+        this.assetsPerWorker = Math.floor(assetNumber / totalWorkers);
+        if (this.workerIndex == 0){
+            const reminder = assetNumber % totalWorkers;
+            this.assetsPerWorker += reminder;
+        } 
+
+        this.byteSize = args.byteSize;
+        this.readSize = args.read ? parseInt(args.read) : 1;//TODO throw error or utput the facttha it defaulted to 1
+        this.writeSize = args.write.number ? parseInt(args.write.number) : 1;//TODO throw error or utput the facttha it defaulted to 1
+        this.previouslyRead = args.write.previouslyRead in writeOptions ? args.write.previouslyRead : writeOptions.random;
+
+        this.asset = {
+            docType: this.chaincodeID,
+            content: '',
+            creator: 'client' + this.workerIndex,
+            byteSize: this.byteSize
+        };
+
+        const paddingSize = this.byteSize - bytes(JSON.stringify(this.asset));
+        this.asset.content = 'B'.repeat(paddingSize);
+    }
+
+    /**
+     * Assemble TXs for the round.
+     * @return {Promise<TxStatus[]>}
+     */
+    async submitTransaction() {
+        // Create argument array [readKeys, writeKeys, otherArgs(String)]
+
+        const readKeys = [];
+        const writeKeys = [];
+
+        const totalRandomIds = this.readSize + this.writeSize;
+        const ids = helper.retrieveRandomAssetIdsFromRange(totalRandomIds, 0, this.assetsPerWorker);
+
+        for (let i = 0; i < this.readSize; i++) {
+            // pick one of the randomized items and remove it from future consideration
+            const uuid = ids.shift(); 
+            const key = 'client' + this.workerIndex + '_' + this.byteSize + '_' + uuid;
+            readKeys.push(key);
+        }
+
+        for(let i = 0; i < this.writeSize; i++){
+            if(i < readKeys.length && this.previouslyRead == writeOptions.read){ //previosly read keys write
+                writeKeys.push(readKeys[i]);
+            } else if (this.previouslyRead == writeOptions.random){ //random keys write
+                const uuid = Math.floor(Math.random() * this.assetsPerWorker);
+                const key = 'client' + this.workerIndex + '_' + this.byteSize + '_' + uuid;
+                writeKeys.push(key);
+            } else { //not already read keys write
+                const uuid = ids.shift();
+                const key = 'client' + this.workerIndex + '_' + this.byteSize + '_' + uuid;
+                writeKeys.push(key);
+            }
+        }
+
+        //generate random letter to use to populate content in the chaincode
+        const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        const letter =  alphabet[Math.floor(Math.random() * alphabet.length)]
+        const args = {
+            contractId: this.chaincodeID,
+            contractFunction: 'readWriteAssets',
+            contractArguments: [JSON.stringify(readKeys), JSON.stringify(writeKeys), letter],
+            readOnly: false
+        };
+    
+        await this.sutAdapter.sendRequests(args);
+    }
+}
+
+/**
+ * Create a new instance of the workload module.
+ * @return {WorkloadModuleInterface}
+ */
+function createWorkloadModule() {
+    return new CompositeTxWorkload();
+}
+
+module.exports.createWorkloadModule = createWorkloadModule;

--- a/benchmarks/api/fabric/workloads/helper.js
+++ b/benchmarks/api/fabric/workloads/helper.js
@@ -24,6 +24,21 @@ module.exports.retrieveRandomAssetIds = function(assetNumber) {
 }
 
 /**
+ * Retrieve an array containing randomized UUIDs from range
+ * @param {number} assetNumber number of random asset uuids required to be in a return array
+ * @param {number} startRange beginning of range from which get the number of random numbers
+ * @param {number} finishRange end of range from which get the number of random numbers
+ */
+ module.exports.retrieveRandomAssetIdsFromRange = function(assetNumber, startRange, finishRange){
+    const difference = finishRange - startRange;
+    const uuids = [];
+    for (let i = 0; i < assetNumber; i++) {
+        uuids[i] = startRange + Math.floor(Math.random() * difference);
+    }
+    return uuids;
+ }
+
+/**
  * Insert asset batches
  * @param {Object} bcObj the BC object
  * @param {Object} context the BC context


### PR DESCRIPTION
Closes #201 

Addresses all points and features of #201 except for random writing of keys. You have to choose if either writes to keys that were already read or not.
I would outline that if you want to only write to already read keys you need to make sure that the number of read keys is equal to or more than the number of write keys; if not you only part (as much as the number of read keys you have) of already read keys and the rest would be new ones.

One possible improvement to the benchmark file could be to automatically derive a number of assets to initialize from the total number of tx multiplied by the read+write transaction instead of having to input it manually in the round definition options.

Signed-off-by: fraVlaca <ocsenarf@outlook.com>