### PR TITLE
readWrite chaincode and benchmark fixes

### DIFF
--- a/benchmarks/api/fabric/read-write-asset.yaml
+++ b/benchmarks/api/fabric/read-write-asset.yaml
@@ -96,7 +96,7 @@ test:
           readCount: 2
           write:
             count: 2
-            previouslyRead: random
+            writeMode: random
     - label: delete-keys-100
       description: >-
         Test a submitTransaction() Gateway method against the

--- a/benchmarks/api/fabric/test.yaml
+++ b/benchmarks/api/fabric/test.yaml
@@ -207,7 +207,7 @@ test:
           readCount: 2
           write:
             count: 2
-            previouslyRead: random
+            writeMode: random
     - label: delete-asset-100
       description: >-
         Test a submitTransaction() Gateway method against the

--- a/benchmarks/api/fabric/workloads/read-write-assets/delete-preloaded-assets.js
+++ b/benchmarks/api/fabric/workloads/read-write-assets/delete-preloaded-assets.js
@@ -49,10 +49,10 @@ class DeletePreloadedAssetsWorkload extends WorkloadModuleBase {
      * Assemble TXs for the round.
      * @return {Promise<TxStatus[]>}
      */
-    async submitTransaction() {
-        for (let i = 0; (i < this.batchesNum) && (this.txIndex < this.assetsPerWorker); i++) {
-            const keys = [];
-            for (let i = 0; i < this.batchSize; i++) {
+     async submitTransaction() {
+        for (let i = 0; i < this.batchesNum; i++) {
+            const keys = []
+            for (let i = 0; (i < this.batchSize) && (this.txIndex < this.assetsPerWorker); i++) {
                 const key = 'client' + this.workerIndex + '_' + this.byteSize + '_' + this.txIndex;
                 keys.push(key);
                 this.txIndex++;

--- a/benchmarks/api/fabric/workloads/read-write-assets/read-write-assets.js
+++ b/benchmarks/api/fabric/workloads/read-write-assets/read-write-assets.js
@@ -5,10 +5,10 @@
 'use strict';
 
 const writeOptions = {
-    read: 'allread',
-    notRead: 'notread',
+    allread: 'allread',
+    notread: 'notread',
     random: 'random',
-  };
+};
 
 const helper = require('../helper');
 const { WorkloadModuleBase } = require('@hyperledger/caliper-core');
@@ -46,8 +46,8 @@ class ReadWriteAssetsWorkload extends WorkloadModuleBase {
         this.chaincodeID = args.chaincodeID ? args.chaincodeID : 'fixed-asset';
         this.assetsPerWorker = helper.getAssetsPerWorker(args.assets, this.workerIndex, totalWorkers);
         this.byteSize = args.byteSize;
-        this.readCount = args.readCount ? parseInt(args.readCount) : 1;//TODO throw error or utput the facttha it defaulted to 1
-        this.writeCount = args.write.count ? parseInt(args.write.count) : 1;//TODO throw error or utput the facttha it defaulted to 1
+        this.readCount = args.readCount ? parseInt(args.readCount) : 1;
+        this.writeCount = args.write.count ? parseInt(args.write.count) : 1;
         this.writeMode = args.write.writeMode in writeOptions ? args.write.writeMode : writeOptions.random;
 
         this.asset = {
@@ -83,7 +83,7 @@ class ReadWriteAssetsWorkload extends WorkloadModuleBase {
 
         for(let i = 0; i < this.writeCount; i++) {
             switch (this.writeMode)  {
-                case writeOptions.read: {
+                case writeOptions.allread: {
                     if (i < readKeys.length) {
                         writeKeys.push(readKeys[i]);
                     } else {
@@ -99,17 +99,14 @@ class ReadWriteAssetsWorkload extends WorkloadModuleBase {
                     writeKeys.push(key);
                     break;
                 }
-                case writeOptions.notRead:{
+                case writeOptions.notread:{
                     const id = ids.shift();
                     const key = 'client' + this.workerIndex + '_' + this.byteSize + '_' + id;
                     writeKeys.push(key);
                     break;
                 }
-                default: {
-                    const id = Math.floor(Math.random() * this.assetsPerWorker);
-                    const key = 'client' + this.workerIndex + '_' + this.byteSize + '_' + id;
-                    writeKeys.push(key);
-                }
+                default:
+                    throw new Error('Unexpected error, most likely a bug in this code. This line should not be executed');
             }
         }
 
@@ -119,7 +116,7 @@ class ReadWriteAssetsWorkload extends WorkloadModuleBase {
         const args = {
             contractId: this.chaincodeID,
             contractFunction: 'readWriteAssets',
-            contractArguments: [JSON.stringify(readKeys), JSON.stringify(writeKeys), JSON.stringify(letter)],
+            contractArguments: [JSON.stringify(readKeys), JSON.stringify(writeKeys), letter],
             readOnly: false
         };
     

--- a/src/fabric/api/fixed-asset-base/go/contracts/FixedAssetContract.go
+++ b/src/fabric/api/fixed-asset-base/go/contracts/FixedAssetContract.go
@@ -6,7 +6,6 @@ import (
 	"fabric/api/fixed-asset-base/go/utils"
 	"fmt"
 	"strings"
-	"unsafe"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 )
@@ -126,11 +125,11 @@ func (contract *FixedAssetContract) GetAssetsFromBatch(ctx utils.Context, batch 
 }
 
 //Delete an Asset from the registry that was created by createAsset
-func (s *FixedAssetContract) DeleteAsset(ctx utils.Context, uuid string) error {
+func (s *FixedAssetContract) DeleteAsset(ctx utils.Context, key string) error {
 	fmt.Println("Entering deleteAsset")
-	fmt.Println(`Returning result for deleteAsset with uuid: ${uuid}`)
+	fmt.Println("Returning result for deleteAsset with key: " + key)
 
-	err := ctx.GetStub().DelState(uuid)
+	err := ctx.GetStub().DelState(key)
 
 	if err != nil {
 		return err
@@ -145,9 +144,8 @@ func (s *FixedAssetContract) DeleteAsset(ctx utils.Context, uuid string) error {
 func (s *FixedAssetContract) DeleteAssetsFromBatch(ctx utils.Context, batch []string) error {
 	fmt.Println("Entering deleteAssetsFromBatch")
 
-	for _, uuid := range batch {
-		fmt.Println(`deleting UUID ${uuid}`)
-		err := ctx.GetStub().DelState(uuid)
+	for _, key := range batch {
+		err := ctx.GetStub().DelState(key)
 
 		if err != nil {
 			return err
@@ -212,45 +210,45 @@ func (contract *FixedAssetContract) PaginatedRangeQuery(ctx utils.Context, start
 	}, nil
 }
 
-//Do y read and x write - directly returns the string
-func (contract *FixedAssetContract) ReadWriteAssets(ctx utils.Context, readUuids []string, writeUiids []string, letter string) error {
-	fmt.Println("Entering ReadWriteAssets()")
+// read and write to selected assets
+func (contract *FixedAssetContract) ReadWriteAssets(ctx utils.Context, readIds []string, writeIds []string, letter string) error {
+	fmt.Println("Entering ReadWriteAssets")
 
-	var fixedAsset *assets.FixedAsset
+	fixedAsset := assets.FixedAsset{}
+	var bytes []byte
 
-	for _, uuid := range readUuids {
-		bytes, err := ctx.GetStub().GetState(uuid)
+	for _, id := range readIds {
+		var err error
+		bytes, err = ctx.GetStub().GetState(id)
 
 		if err != nil {
 			fmt.Println("Error performing GetState: " + err.Error())
 			return err
 		}
-
-		fixedAsset = new(assets.FixedAsset)
-
-		err = json.Unmarshal(bytes, fixedAsset)
-
-		if err != nil {
-			fmt.Println("Error performing json.Unmarshal: " + err.Error())
-			fmt.Println("Error performing json.Unmarshal on bytes: " + string(bytes[:]))
-			return err
-		}
 	}
 
-	byteSize := fixedAsset.Bytesize
-	for _, uuid := range writeUiids {
-		fixedAsset.UUID = uuid
-		paddingSize := byteSize - int(unsafe.Sizeof(fixedAsset))
-		fixedAsset.Content = strings.Repeat(letter, paddingSize)
+	err := json.Unmarshal(bytes, &fixedAsset)
+
+	if err != nil {
+		fmt.Println("Error performing json.Unmarshal: " + err.Error())
+		fmt.Println("Error performing json.Unmarshal on bytes: " + string(bytes[:]))
+		return err
+	}
+
+	maxPaddingSize := len(fixedAsset.Content) + len(fixedAsset.UUID)
+
+	for _, id := range writeIds {
+		fixedAsset.UUID = id
+		fixedAsset.Content = strings.Repeat(letter, maxPaddingSize-len(id))
 		bytes, _ := json.Marshal(fixedAsset)
-		err := ctx.GetStub().PutState(uuid, bytes)
+		err := ctx.GetStub().PutState(id, bytes)
 		if err != nil {
 			fmt.Println("Error performing PutState: " + err.Error())
 			return err
 		}
 	}
 
-	fmt.Println("Exiting ReadWriteAssets()")
+	fmt.Println("Exiting ReadWriteAssets")
 
 	return nil
 }


### PR DESCRIPTION
    - read-write asset tx and benchmark
        - chaincode
            - fixed asset and fixed asset base node
                - deleteAssetFromBatch
                    - delete console.log inside for loop
                    - take out curlies
                - readWriteAsset
                    - update function to new code
            - fixed asset and fixed asset base go
                - readWriteAsset
                    - update function to new code and remove unsafe import
                    - remove brackets
                - deleteasset and delte assetsfrombatch
                    - change uuid to key 
                    - delete log in side the for loop in deleteFromBatch
                    - change delete asset and delte assetfrom bach log 
        - workload
            - change default case for switch , no curly braces beause it is in a single line
            - change from JSON.stringify(letter) to just letter
            - delete comments  
            - change keys for writeOptions to match options of benchamark, hten update switch for new keys
        - fix benchmark previoslyRead variable for random round to writeOptions
        - fix delete preloaded asset benchmark

Signed-off-by: fraVlaca <ocsenarf@outlook.com>