### PR TITLE
fixed paginatRichQuery and paginatedRangeQuery chaincode and benchmark

### DIFF
--- a/benchmarks/api/fabric/mixed-range-query-pagination.yaml
+++ b/benchmarks/api/fabric/mixed-range-query-pagination.yaml
@@ -35,7 +35,7 @@ test:
             - 16000
             - 32000
             - 64000
-          assets: 8000
+          assets: 2000
           range: 200
           offset: 100
           pagesize: '10'

--- a/benchmarks/api/fabric/mixed-rich-query-pagination.yaml
+++ b/benchmarks/api/fabric/mixed-rich-query-pagination.yaml
@@ -33,7 +33,7 @@ test:
             - 2000
             - 4000
             - 8000
-          assets: 8000
+          assets: 2000
           pagesize: '10'
           consensus: false
     - label: mixed-rich-query-evaluate-20

--- a/benchmarks/api/fabric/workloads/range-query-asset.js
+++ b/benchmarks/api/fabric/workloads/range-query-asset.js
@@ -72,7 +72,7 @@ class RangeQueryAssetWorkload extends WorkloadModuleBase {
         const args = {
             contractId: this.chaincodeID,
             contractFunction: 'paginatedRangeQuery',
-            contractArguments: [this.startKey, this.endKey, this.pagesize]
+            contractArguments: [this.startKey, this.endKey, this.pagesize, '']
         };
 
         if (this.consensus) {

--- a/benchmarks/api/fabric/workloads/rich-query-asset.js
+++ b/benchmarks/api/fabric/workloads/rich-query-asset.js
@@ -74,7 +74,7 @@ class RangeQueryAssetWorkload extends WorkloadModuleBase {
         const args = {
             contractId: this.chaincodeID,
             contractFunction: 'paginatedRichQuery',
-            contractArguments: [JSON.stringify(this.mangoQuery), this.pagesize]
+            contractArguments: [JSON.stringify(this.mangoQuery), this.pagesize, '']
         };
 
         if (this.consensus) {

--- a/src/fabric/api/fixed-asset/node/lib/fixed-asset.js
+++ b/src/fabric/api/fixed-asset/node/lib/fixed-asset.js
@@ -325,7 +325,7 @@ class Asset extends Contract {
      * @param {String} bookmark - the bookmark from which to start the return
      * @returns {JSON} the results of the paginated query and responseMetadata in a JSON object
      */
-    async paginatedRichQuery(ctx, queryString, pagesize,  bookmark = '') {
+    async paginatedRichQuery(ctx, queryString, pagesize,  bookmark) {
         if (isVerbose) {
             console.log(`Entering paginated rich query with pagesize [${pagesize}] and query string: ${queryString}`);
         }
@@ -363,7 +363,7 @@ class Asset extends Contract {
      * @param {String} bookmark - the bookmark from which to start the return
      * @returns {JSON} the results of the paginated query and responseMetadata in a JSON object
      */
-    async paginatedRangeQuery(ctx, startKey, endKey, pagesize, bookmark = '') {
+    async paginatedRangeQuery(ctx, startKey, endKey, pagesize, bookmark) {
         if (isVerbose) {
             console.log(`Entering paginatedRangeQuery with pagesize [${pagesize}] and limit keys: [${startKey},${endKey}]`);
         }


### PR DESCRIPTION
The node chaincode uses default parameters while the go one doesn't

In the benchmark we do provide only the required parameters(2 out of 3 for rich query and 3 out of 4 for range query), which works for the node chaincode that has the last parameter as an optional default one while it does not work for the go one.

However, if you try to actually set the third parameter (forth for range query) the go one works fine but the node one doesn't
as far as I understood chaincode functions have a fixed signature with no optional parameters. This is an arbitrary choice since GRPC supports optional parameters by setting them to a default value if missing.

I removed the optional parameter from the node chaincode and provide all of the arguments in the benchmark call.

By reducing the number of assets created everything works fine. however, if we keep the current setting, creating 8000 assets for each worker and size, then around a third of query timeout.
By looking at the couch db logs we see that they eventually finish but after more than 20 seconds.
I solved the issue so that the builds can now pass without errors by reducing the number of asset created. I will close this issue #189 , but open a more specific one on the issues with Couchdb. 

Closes #189

Signed-off-by: fraVlaca <ocsenarf@outlook.com>